### PR TITLE
New picture commands to namegenerator

### DIFF
--- a/namegenerator/README.rst
+++ b/namegenerator/README.rst
@@ -15,7 +15,7 @@ Installation
 
 Let's firstly add my repository if you haven't already:
 
-* :code:`[p]repo add kreusada https://github.com/kreusada/kreusadacogs`
+* :code:`[p]repo add kreusada https://github.com/Kreusada/Kreusada-Cogs`
 
 Next, let's download the cog from the repo:
 
@@ -24,19 +24,6 @@ Next, let's download the cog from the repo:
 Finally, you can see my end user data statements, cog requirements, and other cog information by using:
 
 * :code:`[p]cog info kreusada namegenerator`
-
-------------
-Requirements
-------------
-
-* ``names``
-
-This cog requires the ``names`` module, so you will need to pip install it.
-
-Now also uses ``thispersondoesnotexist``(https://pypi.org/project/thispersondoesnotexist/)
-
-Downloader will attempt to do this for you when you install the cog, so please
-don't worry about it.
 
 -----
 Usage
@@ -110,9 +97,9 @@ Generates a random full name.
 
 .. _namegenerator-command-name-last:
 
-""""""""""
-name first
-""""""""""
+"""""""""
+name last
+"""""""""
 
 **Syntax**
 
@@ -128,41 +115,26 @@ Generates a random last name.
 
 * ``[gender]``: The gender for the name. If none is specified, it defaults to random.
 
-"""""""""
-name picture
-"""""""""
-
-**Syntax**
-
-.. code-block:: ini
-
-    [p]name picture
-
-**Description**
-
-Gets a picture from https://thispersondoesnotexist.com/
-
-**Arguments**
-none
+.. _namegenerator-command-name-mash:
 
 """""""""
-name profile
+name mash
 """""""""
 
 **Syntax**
 
 .. code-block:: ini
 
-    [p]name profile
+    [p]name mash <word1> <word2>
 
 **Description**
 
-Gets a picture from https://thispersondoesnotexist.com/ as well as add a name to it
-WARNING:AS THISPERSONDOESNOTEXIST IS RANDOM, THE GENDERS OF THE NAME AND PICURE MAY NOT MATCH!
+Mashes two words together.
 
 **Arguments**
-none
 
+* ``<word1>``: The first word to mash.
+* ``<member2>``: The second word to mash.
 
 ----------------------
 Additional Information
@@ -175,5 +147,4 @@ For inquiries, see to the contact options below.
 Receive Support
 ---------------
 
-Feel free to ping me at the `Red Cog Support Server <https://discord.gg/GET4DVk>`_ in :code:`#support_othercogs`,
-or you can head over to `my support server <https://discord.gg/JmCFyq7>`_ and ask your questions in :code:`#support-kreusadacogs`.
+Feel free to ping me at the `Red Cog Support Server <https://discord.gg/GET4DVk>`_ in :code:`#support_kreusada-cogs`.

--- a/namegenerator/README.rst
+++ b/namegenerator/README.rst
@@ -32,6 +32,9 @@ Requirements
 * ``names``
 
 This cog requires the ``names`` module, so you will need to pip install it.
+
+Now also uses ``thispersondoesnotexist``(https://pypi.org/project/thispersondoesnotexist/)
+
 Downloader will attempt to do this for you when you install the cog, so please
 don't worry about it.
 
@@ -124,6 +127,42 @@ Generates a random last name.
 **Arguments**
 
 * ``[gender]``: The gender for the name. If none is specified, it defaults to random.
+
+"""""""""
+name picture
+"""""""""
+
+**Syntax**
+
+.. code-block:: ini
+
+    [p]name picture
+
+**Description**
+
+Gets a picture from https://thispersondoesnotexist.com/
+
+**Arguments**
+none
+
+"""""""""
+name profile
+"""""""""
+
+**Syntax**
+
+.. code-block:: ini
+
+    [p]name profile
+
+**Description**
+
+Gets a picture from https://thispersondoesnotexist.com/ as well as add a name to it
+WARNING:AS THISPERSONDOESNOTEXIST IS RANDOM, THE GENDERS OF THE NAME AND PICURE MAY NOT MATCH!
+
+**Arguments**
+none
+
 
 ----------------------
 Additional Information

--- a/namegenerator/info.json
+++ b/namegenerator/info.json
@@ -4,7 +4,7 @@
     "install_msg": "The `names` module is required for this cog to function. Thanks for installing, have fun. Please refer to my docs if you need any help: https://kreusadacogs.readthedocs.io/en/latest/namegenerator.html",
     "short": "Name generator",
     "name": "NameGenerator",
-    "requirements": ["names", "thispersondoesnotexist", "io"],
+    "requirements": ["names", "thispersondoesnotexist"],
     "tags": ["Name", "Random", "Generator"],
     "type": "COG",
     "end_user_data_statement": "This cog does not persistently store data or metadata about users."

--- a/namegenerator/info.json
+++ b/namegenerator/info.json
@@ -4,7 +4,7 @@
     "install_msg": "The `names` module is required for this cog to function. Thanks for installing, have fun. Please refer to my docs if you need any help: https://kreusadacogs.readthedocs.io/en/latest/namegenerator.html",
     "short": "Name generator",
     "name": "NameGenerator",
-    "requirements": ["names"],
+    "requirements": ["names", "thispersondoesnotexist", "io"],
     "tags": ["Name", "Random", "Generator"],
     "type": "COG",
     "end_user_data_statement": "This cog does not persistently store data or metadata about users."

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -102,6 +102,7 @@ class NameGenerator(commands.Cog):
         """
         data = io.BytesIO(await get_online_person())
         await ctx.send(file=discord.File(data, "person.jpeg"))
+        #DrTipmack#1009
 
     @name.command()
     async def profile(self, ctx: commands.Context):
@@ -110,3 +111,4 @@ class NameGenerator(commands.Cog):
         """
         await self.full(ctx)
         await self.picture(ctx)
+        #DrTipmack#1009

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -24,6 +24,8 @@ SOFTWARE.
 
 from names import get_full_name as full, get_first_name as first, get_last_name as last
 from thispersondoesnotexist import get_online_person
+import io
+
 
 
 from redbot.core import commands
@@ -96,4 +98,5 @@ class NameGenerator(commands.Cog):
         """
         Generates a full name and a picture
         """
-        await ctx.send(get_online_person())
+        data = io.BytesIO(await get_online_person().read())
+        await ctx.send(file=discord.File(data, 'person.jpeg'))

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -110,7 +110,7 @@ class NameGenerator(commands.Cog):
         """
         Returns a profile
         """
-        fullName = await fullName()
+        nameFull = await fullName()
 
         embed = discord.Embed(
             title="Here is a fake profile",
@@ -119,7 +119,7 @@ class NameGenerator(commands.Cog):
         )
         embed.add_field(
             name="Name:",
-            value=fullName,
+            value=nameFull,
         )
         embed.set_image(url="https://thispersondoesnotexist.com")
         await ctx.send(embed=embed)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -23,6 +23,8 @@ SOFTWARE.
 """
 
 from names import get_full_name as full, get_first_name as first, get_last_name as last
+from thispersondoesnotexist import get_online_person
+
 
 from redbot.core import commands
 
@@ -32,7 +34,9 @@ class NameGenerator(commands.Cog):
     Generates random names.
     """
 
-    __author__ = ["Kreusada", ]
+    __author__ = [
+        "Kreusada",
+    ]
     __version__ = "1.0.0"
 
     def __init__(self, bot):
@@ -86,3 +90,10 @@ class NameGenerator(commands.Cog):
             await ctx.send(last(gender=gender))
         else:
             await ctx.send(last())
+
+    @name.command()
+    async def picture(self, ctx: commands.Context):
+        """
+        Generates a full name and a picture
+        """
+        await ctx.send(get_online_person())

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -110,5 +110,5 @@ class NameGenerator(commands.Cog):
         """
         Returns a profile
         """
-        self.full(ctx)
-        self.picture(ctx)
+        await self.full(ctx)
+        await self.picture(ctx)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -119,7 +119,7 @@ class NameGenerator(commands.Cog):
         )
         embed.add_field(
             name="Name:",
-            value=name,
+            value=nameFull,
         )
         embed.set_image(url="https://thispersondoesnotexist.com")
         await ctx.send(embed=embed)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -120,5 +120,5 @@ class NameGenerator(commands.Cog):
             name="Name:",
             value=nameFull,
         )
-        embed.set_image("https://thispersondoesnotexist.com/image")
+        embed.set_image(url="https://thispersondoesnotexist.com/image")
         await ctx.send(embed=embed)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -22,7 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from names import get_full_name as full, get_first_name as first, get_last_name as last
+from names import (
+    get_full_name as fullName,
+    get_first_name as first,
+    get_last_name as last,
+)
 from thispersondoesnotexist import get_online_person
 import io
 import discord
@@ -63,9 +67,9 @@ class NameGenerator(commands.Cog):
         `gender`: Provides the gender of the name.
         """
         if gender:
-            await ctx.send(full(gender=gender))
+            await ctx.send(fullName(gender=gender))
         else:
-            await ctx.send(full())
+            await ctx.send(fullName())
 
     @name.command()
     async def first(self, ctx: commands.Context, gender: str = None):
@@ -106,7 +110,7 @@ class NameGenerator(commands.Cog):
         """
         Returns a profile
         """
-        fullName = await ctx.send(full())
+        fullName = await fullName()
 
         embed = discord.Embed(
             title="Here is a fake profile",
@@ -117,7 +121,5 @@ class NameGenerator(commands.Cog):
             name="Name:",
             value=fullName,
         )
-        embed.set_image(
-            url="https://cdn.discordapp.com/avatars/815669652515454976/e590fdee3f5404a212d336179ab35d4f.png?size=1024"
-        )
+        embed.set_image(url="https://thispersondoesnotexist.com")
         await ctx.send(embed=embed)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -111,6 +111,7 @@ class NameGenerator(commands.Cog):
         Returns a profile
         """
         nameFull = fullName()
+        data = io.BytesIO(await get_online_person())
 
         embed = discord.Embed(
             title="Here is a fake profile",
@@ -121,5 +122,5 @@ class NameGenerator(commands.Cog):
             name="Name:",
             value=nameFull,
         )
-        embed.set_image(url="https://thispersondoesnotexist.com")
+        embed.set_image(file=discord.File(data, "person.jpeg"))
         await ctx.send(embed=embed)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -37,12 +37,10 @@ from redbot.core import commands
 
 class NameGenerator(commands.Cog):
     """
-    Generates random names.
+    Generates random names and people.
     """
 
-    __author__ = [
-        "Kreusada",
-    ]
+    __author__ = ["Kreusada", "DrTipmack"]
     __version__ = "1.0.0"
 
     def __init__(self, bot):
@@ -108,7 +106,7 @@ class NameGenerator(commands.Cog):
     @name.command()
     async def profile(self, ctx: commands.Context):
         """
-        Returns a profile
+        Returns a picture and a full name (THE GENDERS MAY NOT MATCH)
         """
         await self.full(ctx)
         await self.picture(ctx)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -110,5 +110,5 @@ class NameGenerator(commands.Cog):
         """
         Returns a profile
         """
-        self.full()
-        self.picture()
+        self.full(ctx)
+        self.picture(ctx)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -110,15 +110,5 @@ class NameGenerator(commands.Cog):
         """
         Returns a profile
         """
-        nameFull = fullName()
-        embed = discord.Embed(
-            title="Here is a fake profile",
-            description="The genders may not match",
-            color=await ctx.embed_colour(),
-        )
-        embed.add_field(
-            name="Name:",
-            value=nameFull,
-        )
-        embed.set_image(url="https://thispersondoesnotexist.com/image")
-        await ctx.send(embed=embed)
+        full()
+        picture()

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -122,5 +122,5 @@ class NameGenerator(commands.Cog):
             name="Name:",
             value=nameFull,
         )
-        embed.set_image(file=discord.File(data, "person.jpeg"))
+        embed.set_image(discord.File(data, "person.jpeg"))
         await ctx.send(embed=embed)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -25,6 +25,7 @@ SOFTWARE.
 from names import get_full_name as full, get_first_name as first, get_last_name as last
 from thispersondoesnotexist import get_online_person
 import io
+import discord
 
 
 from redbot.core import commands

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -96,7 +96,28 @@ class NameGenerator(commands.Cog):
     @name.command()
     async def picture(self, ctx: commands.Context):
         """
-        Generates a full name and a picture
+        Returns a picture from https://thispersondoesnotexist.com/
         """
         data = io.BytesIO(await get_online_person())
         await ctx.send(file=discord.File(data, "person.jpeg"))
+
+    @name.command()
+    async def profile(self, ctx: commands.Context):
+        """
+        Returns a profile
+        """
+        fullName = await ctx.send(full())
+
+        embed = discord.Embed(
+            title="Here is a fake profile",
+            description="The genders may not match",
+            color=await ctx.embed_colour(),
+        )
+        embed.add_field(
+            name="Name:",
+            value=fullName,
+        )
+        embed.set_image(
+            url="https://cdn.discordapp.com/avatars/815669652515454976/e590fdee3f5404a212d336179ab35d4f.png?size=1024"
+        )
+        await ctx.send(embed=embed)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -111,8 +111,6 @@ class NameGenerator(commands.Cog):
         Returns a profile
         """
         nameFull = fullName()
-        data = io.BytesIO(await get_online_person())
-
         embed = discord.Embed(
             title="Here is a fake profile",
             description="The genders may not match",
@@ -122,5 +120,5 @@ class NameGenerator(commands.Cog):
             name="Name:",
             value=nameFull,
         )
-        embed.set_image(discord.File(data, "person.jpeg"))
+        embed.set_image("https://thispersondoesnotexist.com/image")
         await ctx.send(embed=embed)

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -27,7 +27,6 @@ from thispersondoesnotexist import get_online_person
 import io
 
 
-
 from redbot.core import commands
 
 
@@ -98,5 +97,5 @@ class NameGenerator(commands.Cog):
         """
         Generates a full name and a picture
         """
-        data = io.BytesIO(await get_online_person().read())
-        await ctx.send(file=discord.File(data, 'person.jpeg'))
+        data = io.BytesIO(await get_online_person())
+        await ctx.send(file=discord.File(data, "person.jpeg"))

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -110,5 +110,5 @@ class NameGenerator(commands.Cog):
         """
         Returns a profile
         """
-        full()
-        picture()
+        self.full()
+        self.picture()

--- a/namegenerator/names.py
+++ b/namegenerator/names.py
@@ -110,7 +110,7 @@ class NameGenerator(commands.Cog):
         """
         Returns a profile
         """
-        nameFull = await fullName()
+        nameFull = fullName()
 
         embed = discord.Embed(
             title="Here is a fake profile",
@@ -119,7 +119,7 @@ class NameGenerator(commands.Cog):
         )
         embed.add_field(
             name="Name:",
-            value=nameFull,
+            value=name,
         )
         embed.set_image(url="https://thispersondoesnotexist.com")
         await ctx.send(embed=embed)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature
- [ ] Documentation

### Description of the changes
I have added 2 commands: `[p]name picture` and `[p]name profile`:

- `[p]name picture` retrieves a photo from [This website](https://thispersondoesnotexist.com/) and sends it: ![image](https://user-images.githubusercontent.com/57598077/114941805-8665a700-9e3b-11eb-8ad4-66cffcae3437.png)


- `name profile` Is (for now)more of a shorter way of sending a full name and a picture together (it runs `[p]name full` and `[p]name picture` consecutively. Unfortunately, the website I use is random so there is no way of setting genders: ![image](https://user-images.githubusercontent.com/57598077/114941901-a4330c00-9e3b-11eb-9174-2dccbd3837fc.png)


I use a PyPi module [thispersondoesnotexist](https://pypi.org/project/thispersondoesnotexist/) to retrieve the image. There is a way to do this with HTTP instead, so if a new module is undesired, I can change that.

Also, this is my first time messing around with cogs, so the way I send images may be incorrect.
Feel free to change anything you think is problematic 👍

