### PR TITLE
[SpoilerChannel] Break out of the loop

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,7 @@
 /rpsls/* @Kreusada
 /sendcards/* @Kreusada
 /serverblock/* @Kreusada
+/spoilerchannel/* @Kreusada
 /staff/* @Kreusada
 /termino/* @Kreusada
 /textmanipulator/* @Kreusada

--- a/spoilerchannel/spoilerchannel.py
+++ b/spoilerchannel/spoilerchannel.py
@@ -83,9 +83,11 @@ class SpoilerChannel(commands.Cog):
                 if not attachment.is_spoiler():
                     with contextlib.suppress(discord.Forbidden, discord.NotFound):
                         await message.delete()
+                        break
                 elif message.content and not spoiler_check(message.content):
                     with contextlib.suppress(discord.Forbidden, discord.NotFound):
                         await message.delete()
+                        break
         elif not spoiler_check(message.content):
             with contextlib.suppress(discord.Forbidden, discord.NotFound):
                 await message.delete()

--- a/spoilerchannel/spoilerchannel.py
+++ b/spoilerchannel/spoilerchannel.py
@@ -70,6 +70,8 @@ class SpoilerChannel(commands.Cog):
     
     @commands.Cog.listener()
     async def on_message(self, message):
+        if not message.guild:
+            return
         spoiler_check = lambda x: x.strip().startswith("||") and x.strip().endswith("||")
         channels = await self.config.guild(message.guild).channels()
         if await self.bot.cog_disabled_in_guild(self, message.guild):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes

If the message is in a spoiler channel and has attachments that aren't marked with spoiler it will delete and then break out of the for loop

If there is a message with multiple attachments deleting a message once should be enough

Also, if the message has no guild then it will return out of the funcion