### PR TITLE
[Termino] Send message on restart

### DIFF
--- a/termino/termino.py
+++ b/termino/termino.py
@@ -185,7 +185,8 @@ class Termino(commands.Cog):
             f"Shutdown confirmation: {config['confirm_shutdown']}\n\n"
             f"Restart message: {config['restart_message']}\n"
             f"Restart confirmation: {config['confirm_restart']}\n"
-            f"Restarted message (message sent when a successful restart has occurred): {config['restarted_message']}\n\n"
+            f"Restarted message: {config['restarted_message']}\n
+            f"\t- NOTE: This message will be sent in the invoked channel when a successful restart has occured.\n\n"
         )
         if footer:
             message += "{author} will be replaced with the display name of the invoker."

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -19,7 +19,7 @@ class Termino(commands.Cog):
     """Customize bot shutdown and restart messages, with predicates, too."""
 
     __author__ = ["Kreusada"]
-    __version__ = "1.0.0"
+    __version__ = "1.0.1"
 
     def __init__(self, bot):
         self.bot = bot

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -185,7 +185,7 @@ class Termino(commands.Cog):
             f"Shutdown confirmation: {config['confirm_shutdown']}\n\n"
             f"Restart message: {config['restart_message']}\n"
             f"Restart confirmation: {config['confirm_restart']}\n"
-            f"Restarted message: {config['restarted_message']}\n
+            f"Restarted message: {config['restarted_message']}\n"
             f"\t- NOTE: This message will be sent in the invoked channel when a successful restart has occured.\n\n"
         )
         if footer:

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -72,7 +72,11 @@ class Termino(commands.Cog):
         # Or that we cannot find that channel
         if maybe_channel is None or (ch := self.bot.get_channel(maybe_channel)) is None:
             return
-        await ch.send(conf["restarted_message"])
+        try:
+            await ch.send(conf["restarted_message"])
+        except discord.Forbidden as e:
+            log.info("Unable to send a confirmation message to the restart channel")
+            log.debug("Unable to send a message", exc_info=e)
 
     async def confirmation(self, ctx: commands.Context, _type: str):
         await ctx.send(f"Are you sure you want to {_type} {ctx.me.name}? (yes/no)")

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -11,6 +11,8 @@ from redbot.core.utils.predicates import MessagePredicate
 default_wave = "\N{WAVING HAND SIGN}\N{EMOJI MODIFIER FITZPATRICK TYPE-3}"
 log = logging.getLogger("red.kreusada.termino")
 now = datetime.datetime.now().strftime("%d/%m/%Y (%H:%M:%S)")
+shutdown: commands.Command = None
+restart: commands.Command = None
 
 
 class Termino(commands.Cog):
@@ -24,11 +26,14 @@ class Termino(commands.Cog):
         self.config = Config.get_conf(self, 89434930598345, force_registration=True)
         self.config.register_global(
             shutdown_message=f"Shutting down... {default_wave}",
+            restarted_message="I have successfully restarted.",
             restart_message="Restarting...",
+            restart_channel=None,
             confirm_shutdown=True,
             confirm_restart=True,
         )
         self.var_formatter = lambda x, y: y.replace("{author}", x.author.display_name)
+        self.startup_task = self.bot.loop.create_task(self.startup())
 
     def cog_unload(self):
         global shutdown
@@ -45,6 +50,9 @@ class Termino(commands.Cog):
             except Exception as e:
                 log.info(e)
             self.bot.add_command(restart)
+        # This is worse case scenario but still important to check for
+        if self.startup_task:
+            self.startup_task.cancel()
 
     def format_help_for_context(self, ctx: commands.Context) -> str:
         context = super().format_help_for_context(ctx)
@@ -55,14 +63,23 @@ class Termino(commands.Cog):
         """Nothing to delete"""
         return
 
+    async def startup(self):
+        await self.bot.wait_until_red_ready()
+        conf = await self.config.all()
+        maybe_channel = conf.get("restart_channel", None)
+        await self.config.restart_channel.clear()
+        # Using the walrus operator we can check if the channel is originally None
+        # Or that we cannot find that channel
+        if maybe_channel is None or (ch := self.bot.get_channel(maybe_channel)) is None:
+            return
+        await ch.send(conf["restarted_message"])
+
     async def confirmation(self, ctx: commands.Context, _type: str):
         await ctx.send(f"Are you sure you want to {_type} {ctx.me.name}? (yes/no)")
         with contextlib.suppress(asyncio.TimeoutError):
             pred = MessagePredicate.yes_or_no(ctx, user=ctx.author)
             await ctx.bot.wait_for("message", check=pred, timeout=60)
-            if pred.result:
-                return True
-            return False
+            return pred.result
         return False
 
     @commands.is_owner()
@@ -77,6 +94,7 @@ class Termino(commands.Cog):
         if not restart_conf or conf:
             await ctx.send(message)
             log.info(f"{ctx.me.name} was restarted by {ctx.author} ({now})")
+            await self.config.restart_channel.set(ctx.channel.id)
             return await self.bot.shutdown(restart=True)
         else:
             await ctx.send("I will not be restarting.")
@@ -106,7 +124,7 @@ class Termino(commands.Cog):
     async def terminoset_shutdown(self, ctx: commands.Context, *, shutdown_message: str):
         """
         Set and adjust the shutdown message.
-        
+
         You can use `{author}` in your message to send the invokers display name."""
         await ctx.invoke(self.terminoset_shutdown_message, shutdown_message=shutdown_message)
 
@@ -127,7 +145,7 @@ class Termino(commands.Cog):
     async def terminoset_restart(self, ctx: commands.Context, *, restart_message: str):
         """
         Set and adjust the restart message.
-        
+
         You can use `{author}` in your message to send the invokers display name."""
         await ctx.invoke(self.terminoset_restart_message, restart_message=restart_message)
 
@@ -144,6 +162,12 @@ class Termino(commands.Cog):
         await self.config.restart_message.set(restart_message)
         await ctx.send("Restart message set.")
 
+    @terminoset_restart.command(name="restartedmessage", aliases=["resmsg"], usage="<message>")
+    async def terminoset_restarted_message(self, ctx: commands.Context, *, restarted_message: str):
+        """Set the message to be sent after restarting."""
+        await self.config.restarted_message.set(restarted_message)
+        await ctx.send("Restarted messsage set.")
+
     @terminoset.command()
     async def settings(self, ctx: commands.Context):
         """See the current settings for termino."""
@@ -156,21 +180,23 @@ class Termino(commands.Cog):
             f"Shutdown message: {config['shutdown_message']}\n"
             f"Shutdown confirmation: {config['confirm_shutdown']}\n\n"
             f"Restart message: {config['restart_message']}\n"
-            f"Restart confirmation: {config['confirm_restart']}\n\n"
+            f"Restart confirmation: {config['confirm_restart']}\n"
+            f"Restarted message: {config['restarted_message']}\n\n"
         )
         if footer:
             message += "{author} will be replaced with the display name of the invoker."
         for page in pagify(message, delims=["\n"]):
             await ctx.send(box(page, lang="yaml"))
 
+
 def setup(bot):
     cog = Termino(bot)
     global shutdown
     global restart
-    shutdown = bot.get_command("shutdown")
-    restart = bot.get_command("restart")
-    if shutdown:
-        bot.remove_command(shutdown.name)
-    if restart:
-        bot.remove_command(restart.name)
+
+    # `bot.remove_command` will attempt to remove a command and return it back
+    # if no command with the name given exists it will return `None`
+    # So we can skip a large chunk of this code for that reason
+    shutdown = bot.remove_command("shutdown")
+    restart = bot.remove_command("restart")
     bot.add_cog(cog)

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -76,7 +76,7 @@ class Termino(commands.Cog):
             await ch.send(conf["restarted_message"])
         except discord.Forbidden as e:
             log.info("Unable to send a confirmation message to the restart channel")
-            log.debug("Unable to send a message", exc_info=e)
+            log.debug(f"Unable to send a message to channel: {ch.guild} ({ch.guild.id})", exc_info=e)
 
     async def confirmation(self, ctx: commands.Context, _type: str):
         await ctx.send(f"Are you sure you want to {_type} {ctx.me.name}? (yes/no)")
@@ -185,7 +185,7 @@ class Termino(commands.Cog):
             f"Shutdown confirmation: {config['confirm_shutdown']}\n\n"
             f"Restart message: {config['restart_message']}\n"
             f"Restart confirmation: {config['confirm_restart']}\n"
-            f"Restarted message: {config['restarted_message']}\n\n"
+            f"Restarted message (message sent when a successful restart has occurred): {config['restarted_message']}\n\n"
         )
         if footer:
             message += "{author} will be replaced with the display name of the invoker."

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -170,7 +170,7 @@ class Termino(commands.Cog):
     async def terminoset_restarted_message(self, ctx: commands.Context, *, restarted_message: str):
         """Set the message to be sent after restarting."""
         await self.config.restarted_message.set(restarted_message)
-        await ctx.send("Restarted messsage set.")
+        await ctx.send("Restarted message set.")
 
     @terminoset.command()
     async def settings(self, ctx: commands.Context):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes

Sends a message on successful restart. The message sent is customizable by the user. If you would like to change the default message to something else let me know (I'm not creative ._.)

Also simplifies a few things which can be reverted if you don't want them to be changed :D

Closes #78.