### PR TITLE
[Docs] Fix repo installation casing for AdvancedUptime

### DIFF
--- a/advanceduptime/README.rst
+++ b/advanceduptime/README.rst
@@ -15,7 +15,7 @@ Installation
 
 Let's firstly add my repository if you haven't already:
 
-* :code:`[p]repo add Kreusada https://github.com/Kreusada/Kreusada-Cogs`
+* :code:`[p]repo add kreusada https://github.com/Kreusada/Kreusada-Cogs`
 
 Next, let's download the cog from the repo:
 

--- a/docs/cog_advanceduptime.rst
+++ b/docs/cog_advanceduptime.rst
@@ -15,7 +15,7 @@ Installation
 
 Let's firstly add my repository if you haven't already:
 
-* :code:`[p]repo add Kreusada https://github.com/Kreusada/Kreusada-Cogs`
+* :code:`[p]repo add kreusada https://github.com/Kreusada/Kreusada-Cogs`
 
 Next, let's download the cog from the repo:
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature
- [X] Documentation

### Description of the changes
Repo name is case sensitive, install and info commands won't work if the repo name is capitalized.