### PR TITLE
[Raffle] v1.1.0 `end_message` can now be randomized, various hotfixes

### DIFF
--- a/docs/cog_raffle.rst
+++ b/docs/cog_raffle.rst
@@ -67,45 +67,9 @@ The name block is the only required key for a raffle. This block must be under 2
 characters in length. It will automatically be converted to lowercase, and will have
 all spaces removed from it.
 
-This block must be provided as a str (text with quotes)
+This block must be provided as a str (text with quotes).
 
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    RequiredKeyError: The "name" key is required
-
-This exception is raised when the name key is missing, because it is required. To fix
-this, simply add the name key inside of your YAML.
-
-.. code-block:: yaml
-    
-    BadArgument: Name must be str, not [invalid type]
-
-This exception is raised when the name was not provided in the correct type. A simple fix for
-this would be to place quotation marks around your name content.
-
-.. code-block:: yaml
-
-    BadArgument: Name must be under 25 characters, your raffle name had [count]
-
-This exception is raised when your name content has over 25 characters. Be sure to keep it
-nice and short, and then try again with a new name which is under 25 characters.
-
-.. code-block:: yaml
-
-    RaffleSyntaxError: In "name" field, character 5
-
-    test%01
-        ^
-    Characters must be alphanumeric or underscores, not "%"
-
-This exception is raised when your name contains a non-alphanumeric character. Please only
-use letters or numbers in your raffle name. 
-
-.. note::
-
-    Underscores are excluded from this alphanumeric rule, so feel free to use them too.
+Please only use alphanumeric characters, with underscores allowed.
 
 ^^^^^^^^^^^
 description
@@ -115,15 +79,6 @@ The description for your raffle. This information appears in the ``[p]raffle inf
 command, so people can see what your raffle's about.
 
 This block must be provided as a str (text with quotes)
-
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Description must be str, not [invalid type]
-
-This exception is raised when the description was not provided in the correct type. A simple fix for
-this would be to place quotation marks around your description's content.
 
 ^^^^^^^^^^^
 end_message
@@ -150,25 +105,16 @@ to customize this message so that it has context.
         - winner.name_and_discriminator
     
 Make sure to use these variables inside curly brackets (``{}``).
-This condition must be provided as a str (text with quotes).
 
-**Potential Exceptions**
+If you want to randomize the end_message, this is now an option as of version 1.1.0.
+Simply provide a list of strings. Otherwise, provide a string by itself.
 
 .. code-block:: yaml
-    
-    BadArgument: End message must be str
 
-This exception is raised when the end_message was not provided in the correct type. A simple fix 
-for this would be to place quotation marks around your end message's content.
-
-.. code-block:: yaml 
-
-    BadArgument: [arg] was an unexpected argument in your end_message block
-
-This exception is raised when the end_message contains an incorrect argument. For example,
-``{winner.abc}``, or ``{something_that_doesn't_exist}``. These variables do not exist, nor 
-does the ``winner`` variable have an attribute "abc", therefore this exception is raised. 
-Please see above for the list of accepted variables.
+    # randomised
+    end_message: ["Congrats {winner.mention}!", "{winner.name} has won the {raffle} raffle."]
+    # selected
+    end_message: "Congrats {winner.mention}! You have won my {raffle} raffle."
 
 ^^^^^^^^^^^
 account_age
@@ -207,22 +153,6 @@ server for.
 This condition must be a number, and it must be provided in days. This number cannot be higher
 than the server's creation date.
 
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Join age days must be int, not [invalid type]
-
-This exception is raised when the join_age was not provided in the correct type. 
-Please simply provide a number for this condition, without quotes.
-
-.. code-block:: yaml 
-
-    BadArgument: Join age days must be less than this guild's creation date
-
-This exception is raised when the join_age number is higher than the number of days that 
-the current server has existed for. Please try and choose a lower number to make it compatible.
-
 ^^^^^^^^^^^^^^^^^^^^^
 roles_needed_to_enter
 ^^^^^^^^^^^^^^^^^^^^^
@@ -237,42 +167,12 @@ role IDs. In case you were unaware, square brackets (``[]``) are used to denote 
     # One role
     roles_needed_to_enter: [749272596050214973]
 
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Roles must be a list of Discord role IDs, not [invalid type]
-
-This exception is raised when the roles_needed_to_enter was not provided in the correct format. 
-Please provide your discord roles via IDs, and in the format shown above in the example.
-
-.. code-block:: yaml 
-
-    BadArgument: <role id> was not a valid role
-
-This exception is raised when one of the roles provided was not found in the current guild.
-
 ^^^^^^^^^^^^^^^
 prevented_users
 ^^^^^^^^^^^^^^^
 
 A list of users who are not allowed to join the raffle. This must be a **list** of 
 user IDs. Square brackets (``[]``) are used to denote lists.
-
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Users must be a list of Discord user IDs, not [invalid type]
-
-This exception is raised when the prevented_users was not provided in the correct format. 
-Please provide your discord users via IDs, in a list.
-
-.. code-block:: yaml 
-
-    UnknownEntityError: <user id> was not a valid user
-
-This exception is raised when one of the users provided was not found in the current guild.
 
 ^^^^^^^^^^^^^
 allowed_users
@@ -281,36 +181,12 @@ allowed_users
 A list of users who are allowed to join the raffle. This must be a **list** of 
 user IDs. Square brackets (``[]``) are used to denote lists.
 
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Users must be a list of Discord user IDs, not [invalid type]
-
-This exception is raised when the allowed_users was not provided in the correct format. 
-Please provide your discord users via IDs, in a list.
-
-.. code-block:: yaml 
-
-    UnknownEntityError: <user id> was not a valid user
-
-This exception is raised when one of the users provided was not found in the current guild.
-
 ^^^^^^^^^^^^^^^
 maximum_entries
 ^^^^^^^^^^^^^^^
 
 The maximum number of entries allowed into the raffle. This condition must be 
 provided as a number.
-
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Maximum entries must be int, not [invalid type]
-
-This exception is raised when the maximum_entries was not provided in the correct type. 
-Please simply provide a number for this condition, without quotes.
 
 ^^^^^^^^^^^^^
 on_end_action
@@ -324,15 +200,6 @@ This is the prompt for the bot when the a winner is picked for the raffle throug
 * ``keep_winner``: The winner stays in the raffle, and could win again.
 
 If not specified, it defaults to ``keep_winner``.
-
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: on_end_action must be one of 'end', 'remove_winner', or 'keep_winner'
-
-This exception is raised when the on_end_action condition is not in the list provided
-above. These are the only actions available at this time.
 
 .. _raffle-commands:
 
@@ -630,11 +497,15 @@ raffle edit endmessage
 
 Edit the end message of a raffle.
 
-Use `0` or `false` to disable this condition.
+Once you provide an end message, you will have the chance
+to add additional messages, which will be selected at random
+when a winner is drawn.
+
+Use ``0`` or ``false`` to disable this condition.
 
 **Arguments:**
-    - `<raffle>` - The name of the raffle.
-    - `<end_message>` - The new ending message.
+    - ``<raffle>`` - The name of the raffle.
+    - ``<end_message>`` - The new ending message.
 
 .. _raffle-command-raffle-edit-fromyaml:
 

--- a/raffle/README.rst
+++ b/raffle/README.rst
@@ -67,45 +67,9 @@ The name block is the only required key for a raffle. This block must be under 2
 characters in length. It will automatically be converted to lowercase, and will have
 all spaces removed from it.
 
-This block must be provided as a str (text with quotes)
+This block must be provided as a str (text with quotes).
 
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    RequiredKeyError: The "name" key is required
-
-This exception is raised when the name key is missing, because it is required. To fix
-this, simply add the name key inside of your YAML.
-
-.. code-block:: yaml
-    
-    BadArgument: Name must be str, not [invalid type]
-
-This exception is raised when the name was not provided in the correct type. A simple fix for
-this would be to place quotation marks around your name content.
-
-.. code-block:: yaml
-
-    BadArgument: Name must be under 25 characters, your raffle name had [count]
-
-This exception is raised when your name content has over 25 characters. Be sure to keep it
-nice and short, and then try again with a new name which is under 25 characters.
-
-.. code-block:: yaml
-
-    RaffleSyntaxError: In "name" field, character 5
-
-    test%01
-        ^
-    Characters must be alphanumeric or underscores, not "%"
-
-This exception is raised when your name contains a non-alphanumeric character. Please only
-use letters or numbers in your raffle name. 
-
-.. note::
-
-    Underscores are excluded from this alphanumeric rule, so feel free to use them too.
+Please only use alphanumeric characters, with underscores allowed.
 
 ^^^^^^^^^^^
 description
@@ -115,15 +79,6 @@ The description for your raffle. This information appears in the ``[p]raffle inf
 command, so people can see what your raffle's about.
 
 This block must be provided as a str (text with quotes)
-
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Description must be str, not [invalid type]
-
-This exception is raised when the description was not provided in the correct type. A simple fix for
-this would be to place quotation marks around your description's content.
 
 ^^^^^^^^^^^
 end_message
@@ -150,25 +105,16 @@ to customize this message so that it has context.
         - winner.name_and_discriminator
     
 Make sure to use these variables inside curly brackets (``{}``).
-This condition must be provided as a str (text with quotes).
 
-**Potential Exceptions**
+If you want to randomize the end_message, this is now an option as of version 1.1.0.
+Simply provide a list of strings. Otherwise, provide a string by itself.
 
 .. code-block:: yaml
-    
-    BadArgument: End message must be str
 
-This exception is raised when the end_message was not provided in the correct type. A simple fix 
-for this would be to place quotation marks around your end message's content.
-
-.. code-block:: yaml 
-
-    BadArgument: [arg] was an unexpected argument in your end_message block
-
-This exception is raised when the end_message contains an incorrect argument. For example,
-``{winner.abc}``, or ``{something_that_doesn't_exist}``. These variables do not exist, nor 
-does the ``winner`` variable have an attribute "abc", therefore this exception is raised. 
-Please see above for the list of accepted variables.
+    # randomised
+    end_message: ["Congrats {winner.mention}!", "{winner.name} has won the {raffle} raffle."]
+    # selected
+    end_message: "Congrats {winner.mention}! You have won my {raffle} raffle."
 
 ^^^^^^^^^^^
 account_age
@@ -207,22 +153,6 @@ server for.
 This condition must be a number, and it must be provided in days. This number cannot be higher
 than the server's creation date.
 
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Join age days must be int, not [invalid type]
-
-This exception is raised when the join_age was not provided in the correct type. 
-Please simply provide a number for this condition, without quotes.
-
-.. code-block:: yaml 
-
-    BadArgument: Join age days must be less than this guild's creation date
-
-This exception is raised when the join_age number is higher than the number of days that 
-the current server has existed for. Please try and choose a lower number to make it compatible.
-
 ^^^^^^^^^^^^^^^^^^^^^
 roles_needed_to_enter
 ^^^^^^^^^^^^^^^^^^^^^
@@ -237,42 +167,12 @@ role IDs. In case you were unaware, square brackets (``[]``) are used to denote 
     # One role
     roles_needed_to_enter: [749272596050214973]
 
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Roles must be a list of Discord role IDs, not [invalid type]
-
-This exception is raised when the roles_needed_to_enter was not provided in the correct format. 
-Please provide your discord roles via IDs, and in the format shown above in the example.
-
-.. code-block:: yaml 
-
-    BadArgument: <role id> was not a valid role
-
-This exception is raised when one of the roles provided was not found in the current guild.
-
 ^^^^^^^^^^^^^^^
 prevented_users
 ^^^^^^^^^^^^^^^
 
 A list of users who are not allowed to join the raffle. This must be a **list** of 
 user IDs. Square brackets (``[]``) are used to denote lists.
-
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Users must be a list of Discord user IDs, not [invalid type]
-
-This exception is raised when the prevented_users was not provided in the correct format. 
-Please provide your discord users via IDs, in a list.
-
-.. code-block:: yaml 
-
-    UnknownEntityError: <user id> was not a valid user
-
-This exception is raised when one of the users provided was not found in the current guild.
 
 ^^^^^^^^^^^^^
 allowed_users
@@ -281,36 +181,12 @@ allowed_users
 A list of users who are allowed to join the raffle. This must be a **list** of 
 user IDs. Square brackets (``[]``) are used to denote lists.
 
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Users must be a list of Discord user IDs, not [invalid type]
-
-This exception is raised when the allowed_users was not provided in the correct format. 
-Please provide your discord users via IDs, in a list.
-
-.. code-block:: yaml 
-
-    UnknownEntityError: <user id> was not a valid user
-
-This exception is raised when one of the users provided was not found in the current guild.
-
 ^^^^^^^^^^^^^^^
 maximum_entries
 ^^^^^^^^^^^^^^^
 
 The maximum number of entries allowed into the raffle. This condition must be 
 provided as a number.
-
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: Maximum entries must be int, not [invalid type]
-
-This exception is raised when the maximum_entries was not provided in the correct type. 
-Please simply provide a number for this condition, without quotes.
 
 ^^^^^^^^^^^^^
 on_end_action
@@ -324,15 +200,6 @@ This is the prompt for the bot when the a winner is picked for the raffle throug
 * ``keep_winner``: The winner stays in the raffle, and could win again.
 
 If not specified, it defaults to ``keep_winner``.
-
-**Potential Exceptions**
-
-.. code-block:: yaml
-    
-    BadArgument: on_end_action must be one of 'end', 'remove_winner', or 'keep_winner'
-
-This exception is raised when the on_end_action condition is not in the list provided
-above. These are the only actions available at this time.
 
 .. _raffle-commands:
 
@@ -630,11 +497,15 @@ raffle edit endmessage
 
 Edit the end message of a raffle.
 
-Use `0` or `false` to disable this condition.
+Once you provide an end message, you will have the chance
+to add additional messages, which will be selected at random
+when a winner is drawn.
+
+Use ``0`` or ``false`` to disable this condition.
 
 **Arguments:**
-    - `<raffle>` - The name of the raffle.
-    - `<end_message>` - The new ending message.
+    - ``<raffle>`` - The name of the raffle.
+    - ``<end_message>`` - The new ending message.
 
 .. _raffle-command-raffle-edit-fromyaml:
 

--- a/raffle/enums.py
+++ b/raffle/enums.py
@@ -1,5 +1,18 @@
 import enum
 
+class RaffleEMC(enum.Enum):
+    """A list of variables and attributes
+    available for the raffle end_message block."""
+
+    raffle = "The name of the raffle when the end_message is used."
+
+    winner__name = "The username of the winner."
+    winner__mention = "The mention of the winner."
+    winner__id = "The ID of the winner."
+    winner__display_name = "The display name of the winner."
+    winner__discriminator = "The discriminator of the winner."
+    winner__name_and_discriminator = "The name and discriminator of the winner (user#1234)."
+
 class RaffleComponents(enum.Enum):
     """All of the components which can be
     used in a raffle. This class is mainly
@@ -7,51 +20,41 @@ class RaffleComponents(enum.Enum):
     """
 
     name = (
-        str, 
         "The name of the raffle. This is the only REQUIRED field."
     )
 
     description = (
-        str, 
         "The description for the raffle. This information appears in the raffle info command."
     )
 
     end_message = (
-        str,
         "The message used to end the raffle. Defaults to \"Congratulations {winner.mention}, you have won the {raffle} raffle!\""
     )
 
     account_age = (
-        int, 
         "The account age requirement for the user who joins the raffle. This must be specified in days."
     )
 
     join_age = (
-        int, 
         "The number of days the user needs to be in the server for in order to join the raffle."
     )
 
     roles_needed_to_enter = (
-        list, 
         "A list of discord roles which the user must have in order to join the raffle. These MUST be specified using IDs."
     )
 
     prevented_users = (
-        list, 
         "A list of discord users who are not allowed to join the raffle. These MUST be specified using IDs."
     )
 
     allowed_users = (
-        list,
         "A list of discord users who are allowed to join the raffle. If this condition exists, no one will be able to join apart from those in the list."
     )
 
     maximum_entries = (
-        int, 
         "The maximum number of entries allowed for a raffle."
     )
 
     on_end_action = (
-        str,
         "The action to perform when a user is drawn. Must be one of 'end', 'remove_winner', or 'keep_winner', defaults to 'keep_winner'."
     )

--- a/raffle/formatting.py
+++ b/raffle/formatting.py
@@ -1,6 +1,11 @@
 def tick(text):
     return "{} {}".format("\N{BALLOT BOX WITH CHECK}\N{VARIATION SELECTOR-16}", text)
 
-
 def cross(text):
     return "{} {}".format("\N{CROSS MARK}", text)
+
+def curl(enum):
+    return "{{{}}}".format(enum)
+
+def formatenum(enum):
+    return enum.replace("__", ".")

--- a/raffle/helpers.py
+++ b/raffle/helpers.py
@@ -1,13 +1,17 @@
+import asyncio
 import discord
 import yaml
 
 from typing import Union
 from yaml.parser import MarkedYAMLError
 
+from redbot.core.bot import Red as RedBot
 from redbot.core.commands import Context, BadArgument
 from redbot.core.utils.chat_formatting import box
 
 from .safety import RaffleSafeMember
+from .enums import RaffleEMC
+from .formatting import curl, formatenum
 
 
 def format_traceback(exc) -> str:
@@ -32,10 +36,54 @@ def validator(data) -> Union[bool, dict]:
     return loader
 
 
-def raffle_safe_member_scanner(ctx: Context, content: str) -> None:
+def raffle_safe_member_scanner(content: str) -> None:
     """We need this to check if the values are formatted properly."""
     try:
         # This can raise BadArgument, that's fine
         content.format(winner=RaffleSafeMember(discord.Member), raffle=r"{raffle}")
     except KeyError as e:
         raise BadArgument(f"{e} was an unexpected argument in your new end message")
+
+async def start_interactive_end_message_session(ctx: Context, bot: RedBot, message: discord.Message):
+    guide = (
+        "Start adding some messages to add to the list of end messages.\n"
+        "When a user is drawn, one of these messages will be randomly selected.\n"
+        "When you have finished adding messages, **type stop() to discontinue the interactive session.**\n\n"
+        "See below for a list of available variables:"
+    )
+    b = lambda x: box(x, lang="yaml")
+    guide += b("\n".join(f"{curl(formatenum(u.name))}: {u.value}" for u in sorted(RaffleEMC, key=lambda x: len(x.name))))
+    try:
+        await message.edit(content=guide)
+        await message.clear_reactions()
+    except discord.HTTPException:
+        await ctx.send(guide)
+    
+    messages = []
+
+    check = lambda x: x.channel == ctx.channel and x.author == ctx.author
+
+    while True:
+        if not messages:
+            await ctx.send("Add your first response:")
+        elif len(messages) > 20:
+            await ctx.send("That's enough messages!")
+            return messages
+        else:
+            await ctx.send("Add another random response:")
+        try:
+            message = await bot.wait_for("message", check=check, timeout=40)
+        except asyncio.TimeoutError:
+            await ctx.send("You took too long to continue, aborted session.")
+            return False
+        if message.content.lower() == "stop()":
+            if messages:
+                break
+            return False 
+        try:
+            raffle_safe_member_scanner(message.content)
+        except BadArgument:
+            await ctx.send("That message's variables were not formatted correctly, skipping...")
+            continue
+        messages.append(message.content)
+    return messages

--- a/raffle/parser.py
+++ b/raffle/parser.py
@@ -114,14 +114,22 @@ class RaffleManager(object):
                     raise UnknownEntityError(u, "user")
 
         if self.end_message:
-            if not isinstance(self.end_message, str):
+            if not isinstance(self.end_message, (list, str)):
                 # Will render {} without quotes, best not to include the type.__name__ here
-                raise BadArgument("End message must be str")
-            try:
-                # This will raise BadArgument
-                self.end_message.format(winner=RaffleSafeMember(discord.Member), raffle=r"{raffle}")
-            except KeyError as e:
-                raise BadArgument(f"{e} was an unexpected argument in your end_message block")
+                raise BadArgument("End message must be str, or a list of str")
+            if isinstance(self.end_message, str):
+                try:
+                    # This will raise BadArgument
+                    self.end_message.format(winner=RaffleSafeMember(discord.Member), raffle=r"{raffle}")
+                except KeyError as e:
+                    raise BadArgument(f"{e} was an unexpected argument in your end_message block")
+            else:
+                for m in self.end_message:
+                    try:
+                        m.format(winner=RaffleSafeMember(discord.Member), raffle=r"{raffle}")
+                    except KeyError as e:
+                        raise BadArgument(f"{e} was an unexpected argument in your end_message block")
+
 
         if self.on_end_action:
             valid_actions = ("end", "remove_winner", "keep_winner")

--- a/raffle/raffle.py
+++ b/raffle/raffle.py
@@ -1139,11 +1139,11 @@ class Raffle(commands.Cog):
                 "Please provide valid YAML. You can validate your raffle YAML using `{}raffle parse`.".format(ctx.clean_prefix)
             )
 
+        valid["name"] = raffle
+
         try:
             parser = RaffleManager(valid)
             parser.parser(ctx)
-        except RequiredKeyError:
-            pass
         except (RaffleError, BadArgument) as e:
             exc = cross("An exception occured whilst parsing your data.")
             return await ctx.send(exc + format_traceback(e))
@@ -1174,6 +1174,7 @@ class Raffle(commands.Cog):
 
         additions = []
         deletions = []
+        changes = []
 
         for k, v in conditions.items():
             if v and not existing_data[k]:
@@ -1182,16 +1183,20 @@ class Raffle(commands.Cog):
             if not v and existing_data[k]:
                 deletions.append(k)
                 continue
+            if v != existing_data[k]:
+                changes.append(k)
+                continue
 
         if any([additions, deletions]):
             additions = "\n".join(f"+ {a}" for a in additions)
             deletions = "\n".join(f"- {d}" for d in deletions)
+            changes = "\n".join(f"> {c}" for c in changes)
 
-            diffs = box(f"{additions}\n{deletions}", lang="diff")
-            update = tick("Raffle edited. The following conditions have been added/removed: {}".format(diffs))
+            diffs = box(f"{additions}\n{changes}\n{deletions}", lang="diff")
+            update = tick("Raffle edited. The following conditions have been edited: {}".format(diffs))
         
         else:
-            update = tick("Raffle edited. No conditions were added or removed.")
+            update = tick("No changes were made.")
 
         await ctx.send(update)
 

--- a/raffle/raffle.py
+++ b/raffle/raffle.py
@@ -1009,6 +1009,10 @@ class Raffle(commands.Cog):
     @edit.command()
     async def endmessage(self, ctx, raffle: str, *, end_message: Union[bool, str]):
         """Edit the end message of a raffle.
+
+        Once you provide an end message, you will have the chance
+        to add additional messages, which will be selected at random
+        when a winner is drawn.
         
         Use `0` or `false` to disable this condition.
         

--- a/raffle/raffle.py
+++ b/raffle/raffle.py
@@ -55,7 +55,7 @@ class Raffle(commands.Cog):
     """Create raffles for your server."""
 
     __author__ = ["Kreusada"]
-    __version__ = "1.0.3"
+    __version__ = "1.1.0"
 
     def __init__(self, bot):
         self.bot = bot

--- a/raffle/raffle.py
+++ b/raffle/raffle.py
@@ -1062,7 +1062,7 @@ class Raffle(commands.Cog):
                         await ctx.send("End message set to what you provided previously: {}".format(end_message))
                     else:
                         data = [end_message] + interaction
-                        await ctx.send("End message updated for this raffle.")
+                        await ctx.send("End messages updated for this raffle.")
                 else:
                     data = end_message
                     await ctx.send("End message updated for this raffle.")


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes

The `end_message` can now be pulled randomly as long as it is provided to the parser as a list. An interactive function has been created to get these results in a user friendly format.

# Additional Changes

### Fixes

- [x] The RequiredKeyError exception will no longer prevent other conditions from failing to be parsed through the `[p]raffle edit fromyaml` command.

### Enhancements

- [x] `commands.Context` was removed as a required parameter in the `raffle_safe_member_scanner` function as it was not used.
- [x] The `[p]raffle conditions` command, as well as the `RaffleComponents` enum, no longer store conditional types, meaning that there is no more confusion for non-programmers.