### PR TITLE
[Termino] V1.0.4 Rewrite and announcement channel

### DIFF
--- a/termino/info.json
+++ b/termino/info.json
@@ -1,5 +1,5 @@
 {
-    "author" : ["Kreusada"],
+    "author" : ["Kreusada", "Jojo#7791"],
     "description" : "Customize restart and shutdown messages with your own text, and predicates.",
     "disabled" : false,
     "end_user_data_statement" : "This cog does not persistently store data or metadata about users.",

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -20,8 +20,8 @@ restart: commands.Command = None
 class Termino(commands.Cog):
     """Customize bot shutdown and restart messages, with predicates, too."""
 
-    __author__ = ["Kreusada"]
-    __version__ = "1.0.4"
+    __author__ = ["Kreusada", "Jojo#7791"]
+    __version__ = "2.0.0"
 
     def __init__(self, bot):
         self.bot = bot
@@ -63,7 +63,7 @@ class Termino(commands.Cog):
     def format_help_for_context(self, ctx: commands.Context) -> str:
         context = super().format_help_for_context(ctx)
         authors = ", ".join(self.__author__)
-        return f"{context}\n\nAuthor: {authors}\nVersion: {self.__version__}"
+        return f"{context}\n\nAuthors: {authors}\nVersion: {self.__version__}"
 
     async def red_delete_data_for_user(self, **kwargs):
         """Nothing to delete"""


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [x] New feature
- [ ] Documentation

### Description of the changes
Allows the owner to reset the restarted, restart, and shutdown messages.
Also allows the owner to set an announcement channel for when the bot goes offline/comes back online.

Also removes `from random import expovariate` :kappa:

Closes #120 