### PR TITLE
[Raffle] v1.6.1 Use Converters to negate repetitive code

### DIFF
--- a/raffle/commands/editor.py
+++ b/raffle/commands/editor.py
@@ -497,9 +497,9 @@ class EditorCommands(RaffleMixin):
                 return await ctx.send(_("This user is already prevented in this raffle."))
             
             if not prevented:
-                raffle_data["prevented_users"] = [member]
+                raffle_data["prevented_users"] = [member.id]
             else:
-                prevented.append(member)
+                prevented.append(member.id)
 
             await ctx.send(_("{} added to the prevented list for this raffle.".format(member.name)))
 
@@ -682,9 +682,9 @@ class EditorCommands(RaffleMixin):
                 return await ctx.send(_("This user is already allowed in this raffle."))
 
             if not allowed:
-                raffle_data["allowed_users"] = [member]
+                raffle_data["allowed_users"] = [member.id]
             else:
-                allowed.append(member)
+                allowed.append(member.id)
 
             await ctx.send(_("{} added to the allowed list for this raffle.".format(member.name)))
 

--- a/raffle/commands/editor.py
+++ b/raffle/commands/editor.py
@@ -24,6 +24,7 @@ from ..helpers import (
 from ..checks import VALID_USER_BADGES
 from ..formatting import cross, tick
 from ..exceptions import RaffleError, InvalidArgument
+from ..converters import RaffleFactoryConverter
 
     
 _ = Translator("Raffle", __file__)
@@ -42,7 +43,7 @@ class EditorCommands(RaffleMixin):
         pass
 
     @edit.command()
-    async def accage(self, ctx, raffle: str, new_account_age: Union[int, bool]):
+    async def accage(self, ctx, raffle: RaffleFactoryConverter, new_account_age: Union[int, bool]):
         """Edit the account age requirement for a raffle.
         
         Use `0` or `false` to disable this condition.
@@ -54,11 +55,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if isinstance(new_account_age, bool):
                 if not new_account_age:
@@ -80,7 +76,7 @@ class EditorCommands(RaffleMixin):
 
 
     @edit.command()
-    async def serverjoinage(self, ctx, raffle: str, new_server_join_age: Union[int, bool]):
+    async def serverjoinage(self, ctx, raffle: RaffleFactoryConverter, new_server_join_age: Union[int, bool]):
         """Edit the server join age requirement for a raffle.
         
         Use `0` or `false` to disable this condition.
@@ -92,11 +88,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if not new_server_join_age:
                 with contextlib.suppress(KeyError):
@@ -119,7 +110,7 @@ class EditorCommands(RaffleMixin):
 
 
     @edit.command()
-    async def description(self, ctx, raffle: str, *, description: Union[bool, str]):
+    async def description(self, ctx, raffle: RaffleFactoryConverter, *, description: Union[bool, str]):
         """Edit the description for a raffle.
         
         Use `0` or `false` to remove this feature.
@@ -131,11 +122,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-                
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if not description:
                 with contextlib.suppress(KeyError):
@@ -153,7 +139,7 @@ class EditorCommands(RaffleMixin):
 
 
     @edit.command()
-    async def endaction(self, ctx, raffle: str, *, on_end_action: Union[bool, str]):
+    async def endaction(self, ctx, raffle: RaffleFactoryConverter, *, on_end_action: Union[bool, str]):
         """Edit the on_end_action for a raffle.
         
         Use `0` or `false` to remove this feature.
@@ -165,11 +151,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if not on_end_action:
                 with contextlib.suppress(KeyError):
@@ -189,7 +170,7 @@ class EditorCommands(RaffleMixin):
 
 
     @edit.command()
-    async def maxentries(self, ctx, raffle: str, maximum_entries: Union[int, bool]):
+    async def maxentries(self, ctx, raffle: RaffleFactoryConverter, maximum_entries: Union[int, bool]):
         """Edit the max entries requirement for a raffle.
         
         Use `0` or `false` to disable this condition.
@@ -201,11 +182,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if not maximum_entries:
                 with contextlib.suppress(KeyError):
@@ -223,7 +199,7 @@ class EditorCommands(RaffleMixin):
 
 
     @edit.command()
-    async def endmessage(self, ctx, raffle: str, *, end_message: Union[bool, str]):
+    async def endmessage(self, ctx, raffle: RaffleFactoryConverter, *, end_message: Union[bool, str]):
         """Edit the end message of a raffle.
 
         Once you provide an end message, you will have the chance
@@ -239,11 +215,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if not end_message:
                 with contextlib.suppress(KeyError):
@@ -294,7 +265,7 @@ class EditorCommands(RaffleMixin):
         await self.replenish_cache(ctx)
 
     @edit.command()
-    async def joinmessage(self, ctx, raffle: str, *, join_message: Union[bool, str]):
+    async def joinmessage(self, ctx, raffle: RaffleFactoryConverter, *, join_message: Union[bool, str]):
         """Edit the join message of a raffle.
 
         Once you provide a join message, you will have the chance
@@ -310,11 +281,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if not join_message:
                 with contextlib.suppress(KeyError):
@@ -365,7 +331,7 @@ class EditorCommands(RaffleMixin):
         await self.replenish_cache(ctx)
 
     @edit.command()
-    async def fromyaml(self, ctx, raffle: str):
+    async def fromyaml(self, ctx, raffle: RaffleFactoryConverter):
         """Edit a raffle directly from yaml.
         
         **Arguments:**
@@ -374,11 +340,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
         existing_data = {
             "end_message": raffle_data.get("end_message", None),
@@ -519,7 +480,7 @@ class EditorCommands(RaffleMixin):
 
 
     @prevented.command(name="add")
-    async def prevented_add(self, ctx, raffle: str, member: discord.Member):
+    async def prevented_add(self, ctx, raffle: RaffleFactoryConverter, member: discord.Member):
         """Add a member to the prevented list of a raffle.
         
         **Arguments:**
@@ -529,11 +490,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             prevented = raffle_data.get("prevented_users", [])
 
@@ -551,7 +507,7 @@ class EditorCommands(RaffleMixin):
 
 
     @prevented.command(name="remove", aliases=["del"])
-    async def prevented_remove(self, ctx, raffle: str, member: discord.Member):
+    async def prevented_remove(self, ctx, raffle: RaffleFactoryConverter, member: discord.Member):
         """Remove a member from the prevented list of a raffle.
         
         **Arguments:**
@@ -561,11 +517,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             prevented = raffle_data.get("prevented_users", [])
 
@@ -579,7 +530,7 @@ class EditorCommands(RaffleMixin):
 
 
     @prevented.command(name="clear")
-    async def prevented_clear(self, ctx, raffle: str):
+    async def prevented_clear(self, ctx, raffle: RaffleFactoryConverter):
         """Clear the prevented list for a raffle.
         
         **Arguments:**
@@ -588,11 +539,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             prevented = raffle_data.get("prevented_users", None)
 
@@ -637,7 +583,7 @@ class EditorCommands(RaffleMixin):
 
 
     @badges.command(name="add")
-    async def badges_add(self, ctx, raffle: str, *badges: str):
+    async def badges_add(self, ctx, raffle: RaffleFactoryConverter, *badges: str):
         """Add a badge to the required badges list of a raffle.
         
         **Arguments:**
@@ -647,11 +593,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             badges_list = raffle_data.get("badges_needed_to_enter", [])
 
@@ -672,7 +613,7 @@ class EditorCommands(RaffleMixin):
 
 
     @badges.command(name="remove", aliases=["del"])
-    async def badges_remove(self, ctx, raffle: str, *badges: str):
+    async def badges_remove(self, ctx, raffle: RaffleFactoryConverter, *badges: str):
         """Remove a badge from the required badges list of a raffle.
         
         **Arguments:**
@@ -682,11 +623,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             badges_list = raffle_data.get("badges_needed_to_enter", [])
 
@@ -703,7 +639,7 @@ class EditorCommands(RaffleMixin):
 
 
     @badges.command(name="clear")
-    async def badges_clear(self, ctx, raffle: str):
+    async def badges_clear(self, ctx, raffle: RaffleFactoryConverter):
         """Clear the required badges list for a raffle.
         
         **Arguments:**
@@ -712,11 +648,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             badges_list = raffle_data.get("badges_needed_to_enter", None)
 
@@ -734,7 +665,7 @@ class EditorCommands(RaffleMixin):
 
 
     @allowed.command(name="add")
-    async def allowed_add(self, ctx, raffle: str, member: discord.Member):
+    async def allowed_add(self, ctx, raffle: RaffleFactoryConverter, member: discord.Member):
         """Add a member to the allowed list of a raffle.
         
         **Arguments:**
@@ -744,11 +675,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             allowed = raffle_data.get("allowed_users", [])
 
@@ -766,7 +692,7 @@ class EditorCommands(RaffleMixin):
 
 
     @allowed.command(name="remove", aliases=["del"])
-    async def allowed_remove(self, ctx, raffle: str, member: discord.Member):
+    async def allowed_remove(self, ctx, raffle: RaffleFactoryConverter, member: discord.Member):
         """Remove a member from the allowed list of a raffle.
         
         **Arguments:**
@@ -776,11 +702,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             allowed = raffle_data.get("allowed_users", [])
 
@@ -794,16 +715,11 @@ class EditorCommands(RaffleMixin):
 
 
     @allowed.command(name="clear")
-    async def allowed_clear(self, ctx, raffle: str):
+    async def allowed_clear(self, ctx, raffle: RaffleFactoryConverter):
         """Clear the allowed list for a raffle."""
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             allowed = raffle_data.get("allowed_users", None)
 
@@ -851,7 +767,7 @@ class EditorCommands(RaffleMixin):
 
 
     @rolesreq.command(name="add")
-    async def rolesreq_add(self, ctx, raffle: str, role: discord.Role):
+    async def rolesreq_add(self, ctx, raffle: RaffleFactoryConverter, role: discord.Role):
         """Add a role to the role requirements list of a raffle.
         
         **Arguments:**
@@ -861,11 +777,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             roles = raffle_data.get("roles_needed_to_enter", [])
 
@@ -883,7 +794,7 @@ class EditorCommands(RaffleMixin):
 
 
     @rolesreq.command(name="remove", aliases=["del"])
-    async def rolereq_remove(self, ctx, raffle: str, role: discord.Role):
+    async def rolereq_remove(self, ctx, raffle: RaffleFactoryConverter, role: discord.Role):
         """Remove a role from the role requirements list of a raffle.
         
         **Arguments:**
@@ -893,11 +804,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             roles = raffle_data.get("roles_needed_to_enter", [])
 
@@ -911,7 +817,7 @@ class EditorCommands(RaffleMixin):
 
 
     @rolesreq.command(name="clear")
-    async def rolereq_clear(self, ctx, raffle: str):
+    async def rolereq_clear(self, ctx, raffle: RaffleFactoryConverter):
         """Clear the role requirement list for a raffle.
 
         
@@ -921,11 +827,6 @@ class EditorCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             rolesreq = raffle_data.get("roles_needed_to_enter", [])
 

--- a/raffle/commands/informational.py
+++ b/raffle/commands/informational.py
@@ -11,13 +11,14 @@ from ..enums import RaffleComponents
 from ..version_handler import VersionHandler
 from ..formatting import CURRENT_PAGE, LEFT_ARROW, RIGHT_ARROW, square, curl
 from ..parser import RaffleManager
+from ..converters import RaffleExists
 from ..helpers import (
     compose_menu, 
     yield_sectors, 
     listumerate,
     format_underscored_text,
-    revert_underscored_text
 )
+
 
 
 _ = Translator("Raffle", __file__)
@@ -32,7 +33,7 @@ class InformationalCommands(RaffleMixin):
 
 
     @raffle.command()
-    async def info(self, ctx: Context, raffle: str):
+    async def info(self, ctx: Context, raffle: RaffleExists):
         """Get information about a certain raffle.
         
         **Arguments:**
@@ -41,8 +42,6 @@ class InformationalCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
 
         quotes = lambda x: f'"{x}"'
         relevant_data = []
@@ -77,7 +76,7 @@ class InformationalCommands(RaffleMixin):
 
 
     @raffle.command()
-    async def asyaml(self, ctx: Context, raffle: str):
+    async def asyaml(self, ctx: Context, raffle: RaffleExists):
         """Get a raffle in its YAML format.
 
         **Arguments:**
@@ -86,8 +85,6 @@ class InformationalCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
 
         quotes = lambda x: f'"{x}"'
         relevant_data = [("name", quotes(raffle))]
@@ -137,7 +134,7 @@ class InformationalCommands(RaffleMixin):
 
 
     @raffle.command()
-    async def raw(self, ctx: Context, raffle: str):
+    async def raw(self, ctx: Context, raffle: RaffleExists):
         """View the raw dictionary for a raffle.
         
         **Arguments:**
@@ -156,7 +153,7 @@ class InformationalCommands(RaffleMixin):
 
 
     @raffle.command()
-    async def members(self, ctx: Context, raffle: str):
+    async def members(self, ctx: Context, raffle: RaffleExists):
         """Get all the members of a raffle.
         
         **Arguments:**
@@ -165,8 +162,6 @@ class InformationalCommands(RaffleMixin):
         r = await self.config.guild(ctx.guild).raffles()
 
         raffle_data = r.get(raffle, None)
-        if not raffle_data:
-            return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
 
         entries = raffle_data.get("entries")
 

--- a/raffle/commands/management/events.py
+++ b/raffle/commands/management/events.py
@@ -12,6 +12,7 @@ from ...helpers import has_badge, format_underscored_text
 from ...safety import RaffleSafeMember
 from ...checks import account_age_checker, server_join_age_checker
 from ...mixins.abc import RaffleMixin
+from ...converters import RaffleFactoryConverter
 
     
 _ = Translator("Raffle", __file__)  
@@ -27,7 +28,7 @@ class EventCommands(RaffleMixin):
 
 
     @raffle.command()
-    async def draw(self, ctx: Context, raffle: str):
+    async def draw(self, ctx: Context, raffle: RaffleFactoryConverter):
         """Draw a raffle and select a winner.
         
         **Arguments:**
@@ -36,17 +37,11 @@ class EventCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
             raffle_entities = lambda x: raffle_data.get(x, None)
 
             if not raffle_entities("entries"):
                 return await ctx.send(_("There are no participants yet for this raffle."))
 
-            if ctx.author.id not in (raffle_entities("owner"), ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
-                
             winner = random.choice(raffle_entities("entries"))
 
             message = raffle_entities("end_message")
@@ -83,7 +78,7 @@ class EventCommands(RaffleMixin):
         await self.replenish_cache(ctx)
 
     @raffle.command()
-    async def kick(self, ctx: Context, raffle: str, member: discord.Member):
+    async def kick(self, ctx: Context, raffle: RaffleFactoryConverter, member: discord.Member):
         """Kick a member from your raffle.
         
         **Arguments:**
@@ -93,13 +88,7 @@ class EventCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
             raffle_entities = lambda x: raffle_data.get(x)
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if member.id not in raffle_entities("entries"):
                 return await ctx.send(_("This user has not entered this raffle."))
@@ -118,9 +107,6 @@ class EventCommands(RaffleMixin):
         """
         r = await self.config.guild(ctx.guild).raffles()
         raffle_data = r.get(raffle, None)
-
-        if not raffle_data:
-            return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
 
 
         raffle_entities = lambda x: raffle_data.get(x, None)
@@ -206,7 +192,7 @@ class EventCommands(RaffleMixin):
 
 
     @raffle.command()
-    async def mention(self, ctx: Context, raffle: str):
+    async def mention(self, ctx: Context, raffle: RaffleFactoryConverter):
         """Mention all the users entered into a raffle.
         
         **Arguments:**
@@ -215,13 +201,8 @@ class EventCommands(RaffleMixin):
         async with self.config.guild(ctx.guild).raffles() as r:
 
             raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
 
             raffle_entities = lambda x: raffle_data.get(x)
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             if not raffle_entities("entries"):
                 return await ctx.send(_("There are no entries yet for this raffle."))
@@ -233,20 +214,13 @@ class EventCommands(RaffleMixin):
 
 
     @raffle.command()
-    async def end(self, ctx: Context, raffle: str):
+    async def end(self, ctx: Context, raffle: RaffleFactoryConverter):
         """End a raffle.
         
         **Arguments:**
             - `<raffle>` - The name of the raffle to end.
         """
         async with self.config.guild(ctx.guild).raffles() as r:
-
-            raffle_data = r.get(raffle, None)
-            if not raffle_data:
-                return await ctx.send(_("There is not an ongoing raffle with the name `{}`.".format(raffle)))
-
-            if ctx.author.id not in (raffle_data["owner"], ctx.guild.owner_id):
-                return await ctx.send(_("You are not the owner of this raffle."))
 
             msg = await ctx.send(_("Ending the `{raffle}` raffle...".format(raffle=raffle)))
 

--- a/raffle/converters.py
+++ b/raffle/converters.py
@@ -1,0 +1,26 @@
+from redbot.core.commands import BadArgument, Context, Converter
+
+
+class RaffleFactoryConverter(Converter):
+    """A checker which raises BadArgument if the
+    author is not the owner of a raffle or the owner
+    of the guild, or if the raffle doesn't exist."""
+
+    async def convert(self, ctx: Context, argument: str):
+        async with ctx.cog.config.guild(ctx.guild).raffles() as raffles:
+            if not argument in raffles.keys():
+                raise BadArgument("There is not an ongoing raffle with the name `{}`.".format(argument))
+            if ctx.author.id not in (raffles[argument]["owner"], ctx.guild.owner_id):
+                raise BadArgument("You are not the owner of this raffle.")
+        return argument
+
+
+class RaffleExists(Converter):
+    """A checker which raises BadArgument 
+    if the raffle doesn't exist."""
+
+    async def convert(self, ctx: Context, argument: str):
+        async with ctx.cog.config.guild(ctx.guild).raffles() as raffles:
+            if not argument in raffles.keys():
+                raise BadArgument("There is not an ongoing raffle with the name `{}`.".format(argument))
+        return argument

--- a/raffle/info.json
+++ b/raffle/info.json
@@ -1,6 +1,6 @@
 {
     "author": ["Kreusada"],
-    "version": [1, 6, 0],
+    "version": [1, 6, 1],
     "description": "[BETA] Create raffles for your guild, customizable with conditional blocks, and constructed using YAML.",
     "install_msg": "This cog is in pre-release so it is still being developed, but has been opened up for people to try out and test. Please report any issues or feature requests back to me in my support channel in the cog support server (`#support_kreusada-cogs`) https://discord.gg/GET4DVk\nThanks for installing, have fun. Please refer to my docs if you need any help: https://kreusadacogs.readthedocs.io/en/latest/cog_raffle.html",
     "short": "[BETA] Create raffles for your guild, customizable with conditional blocks, and constructed using YAML.",


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes

Added two new converters: RaffleFactoryConverter and RaffleExists.

RaffleFactoryConverter checks if the user has perms to edit a given raffle, and if the raffle exists.
RaffleExists just checks if the raffle exists (informational commands).

See diffs for more details.