### PR TITLE
[Raffle] v1.6.9 Add "suspense_timer" condition (condition #13)

### DIFF
--- a/docs/cog_raffle.rst
+++ b/docs/cog_raffle.rst
@@ -242,6 +242,13 @@ This is the prompt for the bot when the a winner is picked for the raffle throug
 
 If not specified, it defaults to ``keep_winner``.
 
+^^^^^^^^^^^^^^
+suspense_timer
+^^^^^^^^^^^^^^
+
+This condition allows you to set the time for which the bot types when drawing a winner from the raffle.
+This must be provided as a number, and must be between 0 and 10.
+
 .. _raffle-commands:
 
 --------
@@ -886,6 +893,26 @@ Remove a role from the role requirements list of a raffle.
 **Arguments:**
     - `<raffle>` - The name of the raffle.
     - `<role>` - The role to remove from the list of role requirements.
+
+.. _raffle-command-raffle-edit-stimer:
+
+^^^^^^^^^^^^^^^^^^
+raffle edit stimer
+^^^^^^^^^^^^^^^^^^
+
+**Syntax**
+
+.. code-block:: python
+
+    [p]raffle edit stimer <raffle> <suspense_timer>
+
+**Description**
+
+Edit the suspense timer for a raffle.
+
+**Arguments:**
+    - `<raffle>` - The name of the raffle.
+    - `<suspense_timer>` - The new suspense timer for the raffle.
 
 .. _raffle-command-raffle-end:
 

--- a/raffle/README.rst
+++ b/raffle/README.rst
@@ -242,6 +242,13 @@ This is the prompt for the bot when the a winner is picked for the raffle throug
 
 If not specified, it defaults to ``keep_winner``.
 
+^^^^^^^^^^^^^^
+suspense_timer
+^^^^^^^^^^^^^^
+
+This condition allows you to set the time for which the bot types when drawing a winner from the raffle.
+This must be provided as a number, and must be between 0 and 10.
+
 .. _raffle-commands:
 
 --------
@@ -886,6 +893,26 @@ Remove a role from the role requirements list of a raffle.
 **Arguments:**
     - `<raffle>` - The name of the raffle.
     - `<role>` - The role to remove from the list of role requirements.
+
+.. _raffle-command-raffle-edit-stimer:
+
+^^^^^^^^^^^^^^^^^^
+raffle edit stimer
+^^^^^^^^^^^^^^^^^^
+
+**Syntax**
+
+.. code-block:: python
+
+    [p]raffle edit stimer <raffle> <suspense_timer>
+
+**Description**
+
+Edit the suspense timer for a raffle.
+
+**Arguments:**
+    - `<raffle>` - The name of the raffle.
+    - `<suspense_timer>` - The new suspense timer for the raffle.
 
 .. _raffle-command-raffle-end:
 

--- a/raffle/commands/builder.py
+++ b/raffle/commands/builder.py
@@ -105,6 +105,7 @@ class BuilderCommands(RaffleMixin):
                 "description": valid.get("description", None),
                 "maximum_entries": valid.get("maximum_entries", None),
                 "on_end_action": valid.get("on_end_action", None),
+                "suspense_timer": valid.get("suspense_timer", None),
             }
 
             for k, v in conditions.items():

--- a/raffle/commands/editor.py
+++ b/raffle/commands/editor.py
@@ -143,6 +143,39 @@ class EditorCommands(RaffleMixin):
         await self.replenish_cache(ctx)
 
     @edit.command()
+    async def stimer(self, ctx, raffle: RaffleFactoryConverter, suspense_timer: Union[int, bool]):
+        """Edit the suspense timer for a raffle.
+
+        Use `0` or `false` to remove this feature.
+        This feature defaults to 2 seconds if not set.
+
+        **Arguments:**
+            - `<raffle>` - The name of the raffle.
+            - `<description>` - The new suspense timer.
+        """
+        async with self.config.guild(ctx.guild).raffles() as r:
+
+            raffle_data = r.get(raffle, None)
+
+            if not suspense_timer:
+                with contextlib.suppress(KeyError):
+                    del raffle_data["suspense_timer"]
+                return await ctx.send(_("Suspense timer reset to the default: 2 seconds."))
+
+            elif suspense_timer is True:
+                return await ctx.send(
+                    _('Please provide a number, or "false" to disable the description.')
+                )
+
+            else:
+                if not suspense_timer in [*range(0, 11)]:
+                    await ctx.send("New suspense timer must be a number between 0 and 10.")
+                raffle_data["suspense_timer"] = suspense_timer
+                await ctx.send(_("Suspense timer updated for this raffle."))
+
+        await self.replenish_cache(ctx)
+
+    @edit.command()
     async def endaction(
         self, ctx, raffle: RaffleFactoryConverter, *, on_end_action: Union[bool, str]
     ):
@@ -418,6 +451,7 @@ class EditorCommands(RaffleMixin):
             "description": raffle_data.get("description", None),
             "maximum_entries": raffle_data.get("maximum_entries", None),
             "on_end_action": raffle_data.get("on_end_action", None),
+            "suspense_timer": raffle_data.get("suspense_timer", None),
         }
 
         message = (
@@ -500,6 +534,7 @@ class EditorCommands(RaffleMixin):
             "description": valid.get("description", None),
             "maximum_entries": valid.get("maximum_entries", None),
             "on_end_action": valid.get("on_end_action", None),
+            "suspense_timer": valid.get("suspense_timer", None),
         }
 
         for k, v in conditions.items():

--- a/raffle/commands/management/events.py
+++ b/raffle/commands/management/events.py
@@ -56,7 +56,7 @@ class EventCommands(RaffleMixin):
             # Let's add a bit of suspense, shall we? :P
             await ctx.send(_("Picking a winner from the pool..."))
             await ctx.trigger_typing()
-            await asyncio.sleep(2)
+            await asyncio.sleep(raffle_data.get("suspense_timer", 2))
 
             await ctx.send(message)
 

--- a/raffle/info.json
+++ b/raffle/info.json
@@ -5,7 +5,7 @@
     "version": [
         1,
         6,
-        8
+        9
     ],
     "description": "[BETA] Create raffles for your guild, customizable with conditional blocks, and constructed using YAML.",
     "install_msg": "This cog is in pre-release so it is still being developed, but has been opened up for people to try out and test. Please report any issues or feature requests back to me in my support channel in the cog support server (`#support_kreusada-cogs`) https://discord.gg/GET4DVk\nThanks for installing, have fun. Please refer to my docs if you need any help: https://kreusadacogs.readthedocs.io/en/latest/cog_raffle.html",

--- a/raffle/utils/enums.py
+++ b/raffle/utils/enums.py
@@ -110,6 +110,10 @@ class ComponentDescriptions(enum.Enum):
         "a raffle. This must be one of 'end', 'keep_winner', 'remove_winner', or "
         "'remove_and_prevent_winner'."
     )
+    SUSPENSE_TIMER = _(
+        "The amount of seconds that the bot types for before the winner is shown. "
+        "Must be a number between 1 and 10."
+    )
 
 
 class ComponentExamples(enum.Enum):
@@ -127,6 +131,7 @@ class ComponentExamples(enum.Enum):
     ALLOWED_USERS = [719988449867989142]
     MAXIMUM_ENTRIES = 10
     ON_END_ACTION = "remove_and_prevent_winner"
+    SUSPENSE_TIMER = 3
 
 
 class RaffleComponents(enum.Enum):
@@ -241,4 +246,13 @@ class RaffleComponents(enum.Enum):
         "required_condition": False,
         "description": ComponentDescriptions.ON_END_ACTION.value,
         "example": ComponentExamples.ON_END_ACTION.value,
+    }
+
+    suspense_timer: ComponentsDictionary = {
+        "supported_types": [int],
+        "potential_exceptions": [InvalidArgument],
+        "variables": None,
+        "required_condition": False,
+        "description": ComponentDescriptions.SUSPENSE_TIMER.value,
+        "example": ComponentExamples.SUSPENSE_TIMER.value,
     }

--- a/raffle/utils/parser.py
+++ b/raffle/utils/parser.py
@@ -38,6 +38,7 @@ class RaffleManager(object):
         self.join_message = data.get("join_message", None)
         self.end_message = data.get("end_message", None)
         self.on_end_action = data.get("on_end_action", None)
+        self.suspense_timer = data.get("suspense_timer", None)
 
         # dep warnings come first
         if "join_age" in self.data.keys():
@@ -207,3 +208,9 @@ class RaffleManager(object):
                 raise InvalidArgument(
                     "(on_end_action) must be one of 'end', 'remove_winner', 'remove_and_prevent_winner', or 'keep_winner'"
                 )
+
+        if self.suspense_timer:
+            if not isinstance(self.suspense_timer, int) or self.suspense_timer not in [
+                *range(0, 11)
+            ]:
+                raise InvalidArgument("(suspense_timer) must be a number between 0 and 10")


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature
- [ ] Documentation

### Description of the changes

Added the "suspense_timer" condition, where raffle owners can customize the amount of time that the bot types for when drawing a winner for the raffle. This number must be between 0 and 10, and defaults to 2 if not provided. This is the 13th raffle condition.
