### PR TITLE
[Raffle] v1.6.12 Improve raffle cleanup efficiency

### DIFF
--- a/raffle/commands/builder.py
+++ b/raffle/commands/builder.py
@@ -115,7 +115,7 @@ class BuilderCommands(RaffleMixin):
             raffle[rafflename] = data
             await ctx.send(tick(_("Raffle created with the name `{}`.".format(rafflename))))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @create.command()
     async def simple(self, ctx, raffle_name: str, *, description: Optional[str] = None):
@@ -151,3 +151,4 @@ class BuilderCommands(RaffleMixin):
 
             raffle[raffle_name] = data
         await ctx.send(tick(_("Raffle created with the name `{}`.".format(raffle_name))))
+        await self.clean_guild_raffles(ctx)

--- a/raffle/commands/editor.py
+++ b/raffle/commands/editor.py
@@ -72,7 +72,7 @@ class EditorCommands(RaffleMixin):
             raffle_data["account_age"] = new_account_age
             await ctx.send(_("Account age requirement updated for this raffle."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def convertsimple(self, ctx, raffle: RaffleFactoryConverter):
@@ -122,7 +122,7 @@ class EditorCommands(RaffleMixin):
             else:
                 await ctx.send(_("No changes have been made."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def serverjoinage(
@@ -159,7 +159,7 @@ class EditorCommands(RaffleMixin):
                 raffle_data["server_join_age"] = new_server_join_age
                 await ctx.send(_("Server join age requirement updated for this raffle."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def description(
@@ -191,7 +191,7 @@ class EditorCommands(RaffleMixin):
                 raffle_data["description"] = description
                 await ctx.send(_("Description updated for this raffle."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def stimer(self, ctx, raffle: RaffleFactoryConverter, suspense_timer: Union[int, bool]):
@@ -224,7 +224,7 @@ class EditorCommands(RaffleMixin):
                 raffle_data["suspense_timer"] = suspense_timer
                 await ctx.send(_("Suspense timer updated for this raffle."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def endaction(
@@ -267,7 +267,7 @@ class EditorCommands(RaffleMixin):
                 raffle_data["on_end_action"] = on_end_action
                 await ctx.send(_("On end action updated for this raffle."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def maxentries(
@@ -299,7 +299,7 @@ class EditorCommands(RaffleMixin):
                 raffle_data["maximum_entries"] = maximum_entries
                 await ctx.send(_("Max entries requirement updated for this raffle."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def endmessage(
@@ -387,7 +387,7 @@ class EditorCommands(RaffleMixin):
                     await ctx.send(_("End message updated for this raffle."))
                 raffle_data["end_message"] = data
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def joinmessage(
@@ -477,7 +477,7 @@ class EditorCommands(RaffleMixin):
                     await ctx.send(_("Join message updated for this raffle."))
                 raffle_data["join_message"] = data
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.command()
     async def fromyaml(self, ctx, raffle: RaffleFactoryConverter):
@@ -627,7 +627,7 @@ class EditorCommands(RaffleMixin):
 
         await ctx.send(update)
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.group()
     async def prevented(self, ctx):
@@ -660,7 +660,7 @@ class EditorCommands(RaffleMixin):
                 _("{} added to the prevented list for this raffle.".format(member.name))
             )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @prevented.command(name="remove", aliases=["del"])
     async def prevented_remove(self, ctx, raffle: RaffleFactoryConverter, member: discord.Member):
@@ -686,7 +686,7 @@ class EditorCommands(RaffleMixin):
                 _("{} remove from the prevented list for this raffle.".format(member.name))
             )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @prevented.command(name="clear")
     async def prevented_clear(self, ctx, raffle: RaffleFactoryConverter):
@@ -780,7 +780,7 @@ class EditorCommands(RaffleMixin):
                 )
             )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @badges.command(name="remove", aliases=["del"])
     async def badges_remove(self, ctx, raffle: RaffleFactoryConverter, *badges: str):
@@ -817,7 +817,7 @@ class EditorCommands(RaffleMixin):
                 )
             )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @badges.command(name="clear")
     async def badges_clear(self, ctx, raffle: RaffleFactoryConverter):
@@ -867,7 +867,7 @@ class EditorCommands(RaffleMixin):
 
             await ctx.send(_("{} added to the allowed list for this raffle.".format(member.name)))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @allowed.command(name="remove", aliases=["del"])
     async def allowed_remove(self, ctx, raffle: RaffleFactoryConverter, member: discord.Member):
@@ -893,7 +893,7 @@ class EditorCommands(RaffleMixin):
                 _("{} removed from the allowed list for this raffle.".format(member.name))
             )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @allowed.command(name="clear")
     async def allowed_clear(self, ctx, raffle: RaffleFactoryConverter):
@@ -938,7 +938,7 @@ class EditorCommands(RaffleMixin):
         else:
             await ctx.send(_("No changes have been made."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @edit.group()
     async def rolesreq(self, ctx):
@@ -971,7 +971,7 @@ class EditorCommands(RaffleMixin):
                 _("{} added to the role requirement list for this raffle.".format(role.name))
             )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @rolesreq.command(name="remove", aliases=["del"])
     async def rolereq_remove(self, ctx, raffle: RaffleFactoryConverter, role: discord.Role):
@@ -995,7 +995,7 @@ class EditorCommands(RaffleMixin):
                 _("{} remove from the role requirement list for this raffle.".format(role.name))
             )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @rolesreq.command(name="clear")
     async def rolereq_clear(self, ctx, raffle: RaffleFactoryConverter):
@@ -1048,4 +1048,4 @@ class EditorCommands(RaffleMixin):
             else:
                 await ctx.send(_("No changes have been made."))
 
-            await self.replenish_cache(ctx)
+            await self.clean_guild_raffles(ctx)

--- a/raffle/commands/informational.py
+++ b/raffle/commands/informational.py
@@ -64,7 +64,7 @@ class InformationalCommands(RaffleMixin):
         ):
             await ctx.send(box(page, lang="yaml"))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def asyaml(self, ctx: Context, raffle: RaffleExists):
@@ -92,7 +92,7 @@ class InformationalCommands(RaffleMixin):
             message + box("\n".join(f"{x[0]}: {x[1]}" for x in relevant_data), lang="yaml")
         )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command(name="list")
     async def _list(self, ctx: Context):
@@ -120,7 +120,7 @@ class InformationalCommands(RaffleMixin):
             embeds.append(embed)
 
         await compose_menu(ctx, embeds)
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def raw(self, ctx: Context, raffle: RaffleExists):
@@ -133,7 +133,7 @@ class InformationalCommands(RaffleMixin):
         for page in pagify(str({raffle: r[raffle]}), page_length=1985):
             await ctx.send(box(page, lang="json"))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def members(self, ctx: Context, raffle: RaffleExists):
@@ -172,7 +172,7 @@ class InformationalCommands(RaffleMixin):
             embed_pages.append(embed)
 
         await compose_menu(ctx, embed_pages)
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def conditions(self, ctx: Context):
@@ -254,7 +254,7 @@ class InformationalCommands(RaffleMixin):
             )
             pages.append(embed)
         await compose_menu(ctx, pages)
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def version(self, ctx: Context):

--- a/raffle/commands/management/events.py
+++ b/raffle/commands/management/events.py
@@ -74,7 +74,7 @@ class EventCommands(RaffleMixin):
                 # end
                 r.pop(raffle)
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def kick(self, ctx: Context, raffle: RaffleFactoryConverter, member: discord.Member):
@@ -95,7 +95,7 @@ class EventCommands(RaffleMixin):
             raffle_entities("entries").remove(member.id)
             await ctx.send(_("User removed from the raffle."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def join(self, ctx: Context, raffle: RaffleExists):
@@ -194,7 +194,7 @@ class EventCommands(RaffleMixin):
             welcome_msg += "\n---\n{}".format(join_message)
 
         await ctx.send(welcome_msg)
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def leave(self, ctx: Context, raffle: RaffleExists):
@@ -216,7 +216,7 @@ class EventCommands(RaffleMixin):
                 _("{0.mention} you have been removed from the raffle.".format(ctx.author))
             )
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def mention(self, ctx: Context, raffle: RaffleFactoryConverter):
@@ -239,7 +239,7 @@ class EventCommands(RaffleMixin):
             ):
                 await ctx.send(page)
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
     @raffle.command()
     async def end(self, ctx: Context, raffle: RaffleFactoryConverter):
@@ -258,4 +258,4 @@ class EventCommands(RaffleMixin):
         with contextlib.suppress(discord.NotFound):
             await msg.edit(content=_("Raffle ended."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)

--- a/raffle/commands/management/misc.py
+++ b/raffle/commands/management/misc.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+
 from raffle.utils.converters import RaffleFactoryConverter
 
 import discord

--- a/raffle/commands/management/misc.py
+++ b/raffle/commands/management/misc.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+from raffle.utils.converters import RaffleFactoryConverter
 
 import discord
 from redbot.core import commands
@@ -57,17 +58,35 @@ class MiscCommands(RaffleMixin):
 
         await ctx.send(tick(_("This YAML is good to go! No errors were found.")))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)
 
-    @raffle.command()
+    @raffle.group(invoke_without_command=True)
+    async def refresh(self, ctx: Context, raffle: RaffleFactoryConverter):
+        """Refresh raffle(s)."""
+        cleaner = await self.clean_singular_raffle(ctx, raffle)
+        if cleaner:
+            return await ctx.send(_("Raffle updated."))
+        else:
+            return await ctx.send(_("Everything was already up to date."))
+
     @commands.guildowner()
-    async def refresh(self, ctx: Context):
-        """Refresh all of the raffle caches."""
-        cleaner = await self.replenish_cache(ctx)
+    @refresh.command(name="guild")
+    async def refresh_guild(self, ctx: Context):
+        """Refresh this guild's raffles."""
+        await ctx.trigger_typing()
+        cleaner = await self.clean_guild_raffles(ctx)
         if cleaner:
             return await ctx.send(_("Raffles updated."))
         else:
             return await ctx.send(_("Everything was already up to date."))
+
+    @commands.is_owner()
+    @refresh.command(name="global")
+    async def refresh_global(self, ctx: Context):
+        """Refresh global raffles."""
+        await ctx.trigger_typing()
+        await self.initialize()
+        await ctx.send("Global raffles updated.")
 
     @raffle.command()
     @commands.guildowner()
@@ -109,4 +128,4 @@ class MiscCommands(RaffleMixin):
         else:
             await ctx.send(_("No changes have been made."))
 
-        await self.replenish_cache(ctx)
+        await self.clean_guild_raffles(ctx)

--- a/raffle/info.json
+++ b/raffle/info.json
@@ -5,7 +5,7 @@
     "version": [
         1,
         6,
-        11
+        12
     ],
     "description": "[BETA] Create raffles for your guild, customizable with conditional blocks, and constructed using YAML.",
     "install_msg": "This cog is in pre-release so it is still being developed, but has been opened up for people to try out and test. Please report any issues or feature requests back to me in my support channel in the cog support server (`#support_kreusada-cogs`) https://discord.gg/GET4DVk\nThanks for installing, have fun. Please refer to my docs if you need any help: https://kreusadacogs.readthedocs.io/en/latest/cog_raffle.html",

--- a/raffle/raffle.py
+++ b/raffle/raffle.py
@@ -12,8 +12,8 @@ from .commands.editor import EditorCommands
 from .commands.informational import InformationalCommands
 from .commands.management.events import EventCommands
 from .commands.management.misc import MiscCommands
-from .utils.cleanup import CleanupHelpers
 from .mixins.metaclass import MetaClass
+from .utils.cleanup import CleanupHelpers
 from .version_handler import VersionHandler
 
 RaffleCog = getattr(commands, "Cog", object)

--- a/raffle/utils/cleanup.py
+++ b/raffle/utils/cleanup.py
@@ -1,0 +1,127 @@
+from redbot.core.commands import Context
+
+from ..log import log
+from ..mixins.abc import RaffleMixin
+
+
+class CleanupHelpers(RaffleMixin):
+    """Various utilities to prevent stale dictionary values"""
+
+    async def clean_raffles(self, ctx: Context) -> None:
+        async with self.config.guild(ctx.guild).raffles() as r:
+
+            updates = {}
+
+            for k, v in list(r.items()):
+
+                getter = v.get("owner")
+                if not ctx.guild.get_member(getter):
+                    del r[k]
+                    updates["owner"] = True
+
+                getter = v.get("entries")
+                for userid in getter:
+                    if not ctx.guild.get_member(userid):
+                        getter.remove(userid)
+                        updates["entries"] = True
+
+                getter = v.get("prevented_users", None)
+                if getter:
+                    for userid in getter:
+                        if not ctx.guild.get_member(userid):
+                            getter.remove(userid)
+                            updates["prevented_users"] = True
+
+                getter = v.get("allowed_users", None)
+                if getter:
+                    for userid in getter:
+                        if not ctx.guild.get_member(userid):
+                            getter.remove(userid)
+                            updates["allowed_users"] = True
+
+                getter = v.get("roles_needed_to_enter", None)
+                if getter:
+                    for roleid in getter:
+                        if not ctx.guild.get_role(roleid):
+                            getter.remove(roleid)
+                            updates["roles_needed_to_enter"] = True
+
+        return any(updates.values())
+
+    @property
+    def clean_guild_raffles(self):
+        return self.clean_raffles
+
+    async def initialize(self):
+        all_guilds = await self.config.all_guilds()
+        changed_guilds = []
+        for g in all_guilds.keys():
+            gobj = self.bot.get_guild(g)
+            if not gobj:
+                continue
+            raffles = all_guilds[g]["raffles"]
+            for r in raffles.keys():
+                IDS = {}
+                if raffles[r] and "roles" in r:
+                    IDS[r] = "get_role"
+                elif raffles[r] and "users" in r:
+                    IDS[r] = "get_member"
+                else:
+                    continue
+
+                if not gobj.get_member(raffles[r]["owner"]):
+                    del raffles[r]
+                    changed_guilds.append(g)
+
+                for k, v in IDS.items():
+                    for obj in raffles[k]:
+                        if not getattr(gobj, f"get_{v}")(obj):
+                            del raffles[k][obj]
+                            changed_guilds.append(g)
+        await self.config.guild(gobj).raffles.set(raffles)
+        log.info("Raffles cleaned up across %s guilds" % len(all_guilds.keys()))
+        if changed_guilds:
+            log.info(
+                "%s guild raffle dictionaries were edited to remove deleted/unknown users and roles"
+                % len(changed_guilds)
+            )
+
+    async def clean_singular_raffle(self, ctx: Context, raffle: str) -> None:
+        async with self.config.guild(ctx.guild).raffles() as r:
+
+            updates = {}
+            raffle_data = r[raffle]
+
+            getter = raffle_data.get("owner")
+            if not ctx.guild.get_member(getter):
+                del r[raffle][getter]
+                updates["owner"] = True
+
+            getter = raffle_data.get("entries")
+            for userid in getter:
+                if not ctx.guild.get_member(userid):
+                    getter.remove(userid)
+                    updates["entries"] = True
+
+            getter = raffle_data.get("prevented_users", None)
+            if getter:
+                for userid in getter:
+                    if not ctx.guild.get_member(userid):
+                        getter.remove(userid)
+                        updates["prevented_users"] = True
+
+            getter = raffle_data.get("allowed_users", None)
+            if getter:
+                for userid in getter:
+                    if not ctx.guild.get_member(userid):
+                        getter.remove(userid)
+                        updates["allowed_users"] = True
+
+            getter = raffle_data.get("roles_needed_to_enter", None)
+            if getter:
+                for roleid in getter:
+                    if not ctx.guild.get_role(roleid):
+                        getter.remove(roleid)
+                        updates["roles_needed_to_enter"] = True
+
+        return any(updates.values())


### PR DESCRIPTION
Increment the number of times that the cleaner is called in order to cleanup raffles for "dead" user and role IDs. Add separate functions for cleaning singular raffles, and then all raffles in a guild, and all raffles globally. Adding two new commands which will help to rejuvenate guild and global raffles.

TODO: Update documentation with new refresh commands.