### PR TITLE
[Termino] Fix config migration

### DIFF
--- a/termino/termino.py
+++ b/termino/termino.py
@@ -22,7 +22,7 @@ class Termino(Utilities, commands.Cog, metaclass=CompositeMetaClass):
 
     __author__ = ["Kreusada", "Jojo#7791"]
     __dev_ids__ = [719988449867989142, 544974305445019651]
-    __version__ = "2.0.3"
+    __version__ = "2.0.4"
 
     def __init__(self, bot):
         self.bot = bot

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -80,9 +80,9 @@ class Termino(Utilities, commands.Cog, metaclass=CompositeMetaClass):
             if uid in self.bot.owner_ids:
                 with contextlib.suppress(RuntimeError, ValueError):
                     self.bot.add_dev_env_value("termino", lambda x: self)
-        conf = await self.config.all()
-        if "announced" in conf.keys():
-            await self.config.announced.clear()
+
+        # remove no longer used config key
+        await self.config.clear_raw("announced")
 
     @commands.is_owner()
     @commands.command()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes
`force_registration` is set to `True` and therefore you can't access values that aren't registered through attribute lookup. This PR uses `clear_raw()` method instead which due to its raw-ness does not check whether the value is registered. I also removed the `.all()` check since `clear_raw()` won't raise when the key isn't there anyway.