### PR TITLE
[Raffle] v1.7.1 Add RaffleNameConverter for simple raffles

### DIFF
--- a/raffle/commands/builder.py
+++ b/raffle/commands/builder.py
@@ -10,6 +10,7 @@ from redbot.core.utils.chat_formatting import box
 
 from ..mixins.abc import RaffleMixin
 from ..mixins.metaclass import MetaClass
+from ..utils.converters import RaffleNameConverter
 from ..utils.enums import RaffleComponents
 from ..utils.exceptions import RaffleError
 from ..utils.formatting import cross, tick
@@ -119,7 +120,7 @@ class BuilderCommands(RaffleMixin, metaclass=MetaClass):
         await self.clean_guild_raffles(ctx)
 
     @create.command()
-    async def simple(self, ctx, raffle_name: str, *, description: Optional[str] = None):
+    async def simple(self, ctx, raffle_name: RaffleNameConverter, *, description: Optional[str] = None):
         """Create a simple arguments with just a name and description.
 
         **Arguments:**

--- a/raffle/commands/builder.py
+++ b/raffle/commands/builder.py
@@ -120,7 +120,9 @@ class BuilderCommands(RaffleMixin, metaclass=MetaClass):
         await self.clean_guild_raffles(ctx)
 
     @create.command()
-    async def simple(self, ctx, raffle_name: RaffleNameConverter, *, description: Optional[str] = None):
+    async def simple(
+        self, ctx, raffle_name: RaffleNameConverter, *, description: Optional[str] = None
+    ):
         """Create a simple arguments with just a name and description.
 
         **Arguments:**

--- a/raffle/utils/converters.py
+++ b/raffle/utils/converters.py
@@ -39,9 +39,7 @@ class RaffleNameConverter(Converter):
     async def convert(self, ctx: Context, argument: str):
         if len(argument) > 25:
             raise BadArgument(
-                "Name must be under 25 characters, your raffle name had {}.".format(
-                    len(argument)
-                )
+                "Name must be under 25 characters, your raffle name had {}.".format(len(argument))
             )
         for char in argument:
             if char == "_":

--- a/raffle/utils/converters.py
+++ b/raffle/utils/converters.py
@@ -33,3 +33,21 @@ class RaffleExists(Converter):
                     "There is not an ongoing raffle with the name `{}`.".format(argument)
                 )
         return argument
+
+
+class RaffleNameConverter(Converter):
+    async def convert(self, ctx: Context, argument: str):
+        if len(argument) > 25:
+            raise BadArgument(
+                "Name must be under 25 characters, your raffle name had {}.".format(
+                    len(argument)
+                )
+            )
+        for char in argument:
+            if char == "_":
+                # We want to allow underscores
+                continue
+            if not char.isalnum():
+                raise BadArgument(f"`{char}` is not an alphanumeric character.")
+
+        return argument


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes

Simple raffles were able to evade the raffle naming convention rules because they were not checked. This PR adds a converter to make sure the names are suitable before the raffle is created.
