### PR TITLE
[Pypi] Pagify classifiers if it's over a certain length

### DIFF
--- a/pypi/pypi.py
+++ b/pypi/pypi.py
@@ -1,7 +1,6 @@
 import contextlib
 import io
 import json
-import logging
 import re
 from pathlib import Path
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes
This fixes an issue when the classifier data is over the char limit of an embed field.

Also, it didn't take me the weekend to figure out :D

Closes #177 