### PR TITLE
[TimeStamps] Add relative timestamp variant

### DIFF
--- a/timestamps/info.json
+++ b/timestamps/info.json
@@ -9,7 +9,9 @@
     "install_msg": "Thanks for installing, have fun. Please refer to my docs if you need any help: https://kreusadacogs.readthedocs.io/en/latest/cog_timestamps.html",
     "name": "TimeStamps",
     "required_cogs": {},
-    "requirements": ["dateparser"],
+    "requirements": [
+        "dateparser"
+    ],
     "short": "Produce Discord timestamps.",
     "tags": [
         "Timestamps",

--- a/timestamps/timestamps.py
+++ b/timestamps/timestamps.py
@@ -55,8 +55,8 @@ class TimeStamps(Cog):
     async def timestamp(self, ctx: Context, *, dti: DateConverter):
         """Produce a Discord timestamp.
 
-        Timestamps are a feature added to Discord in the summer of 2021, 
-        which allows you to send timestamps will which update accordingly 
+        Timestamps are a feature added to Discord in the summer of 2021,
+        which allows you to send timestamps will which update accordingly
         with any user's date time settings.
 
         **Example Usage**


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes

https://canary.discord.com/channels/240154543684321280/824430504232484885/896985253397299260 This issue was reported in the support channel, so I implemented it. The relative timestamp is shown at the end of the list, and example is;
![kreu-pr-image](https://user-images.githubusercontent.com/69662328/136750220-06696a78-9d45-4e34-8c55-373361844e6e.png)
