### PR TITLE
[TimeStamps] Fix unlocalized header

### DIFF
--- a/timestamps/timestamps.py
+++ b/timestamps/timestamps.py
@@ -22,13 +22,6 @@ class DateConverter(Converter):
             raise BadArgument("Unrecognized date/time.")
         return parsed
 
-    @staticmethod
-    def get_superscript(number: int) -> str:
-        suffixes = {0: "th", 1: "st", 2: "nd", 3: "rd"}
-        for i in range(4, 10):
-            suffixes[i] = "th"
-        return str(number) + suffixes[int(str(number)[-1])]
-
 
 class TimeStamps(Cog):
     """Retrieve timestamps for certain dates."""


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes
The problem was that it was showing using the bot's timezone in header, while all the rest is localized timestamps.
Fixes #190.
