### PR TITLE
[Meta] Update datetime.now logic

### DIFF
--- a/raffle/info.json
+++ b/raffle/info.json
@@ -5,7 +5,7 @@
     "version": [
         1,
         7,
-        5
+        6
     ],
     "description": "Create raffles for your guild, customizable with conditional blocks, and constructed using YAML.",
     "install_msg": "This cog is in pre-release so it is still being developed, but has been opened up for people to try out and test. Please report any issues or feature requests back to me in my support channel in the cog support server (`#support_kreusada-cogs`) https://discord.gg/GET4DVk\nThanks for installing, have fun. Please refer to my docs if you need any help: https://kreusadacogs.readthedocs.io/en/latest/cog_raffle.html",

--- a/raffle/utils/checks.py
+++ b/raffle/utils/checks.py
@@ -1,5 +1,5 @@
-account_age_checker = lambda x: x < (now - discord_creation_date).days
-server_join_age_checker = lambda ctx, x: x < (now - ctx.guild.created_at).days
+account_age_checker = lambda x: x < (now() - discord_creation_date).days
+server_join_age_checker = lambda ctx, x: x < (now() - ctx.guild.created_at).days
 
 import datetime
 

--- a/termino/termino.py
+++ b/termino/termino.py
@@ -12,9 +12,9 @@ from redbot.core.utils.predicates import MessagePredicate
 
 from .log import log
 from .mixins import CompositeMetaClass
-from .utils import Utilities, default_wave
+from .utils import Utilities, default_wave, now
 
-now = datetime.datetime.now().strftime("%d/%m/%Y (%H:%M:%S)")
+nowstf = lambda: now().strftime("%d/%m/%Y (%H:%M:%S)")
 shutdown: commands.Command = None
 restart: commands.Command = None
 
@@ -27,7 +27,7 @@ class Termino(Utilities, commands.Cog, metaclass=CompositeMetaClass):
 
     __author__ = ["Kreusada", "Jojo#7791"]
     __dev_ids__ = [719988449867989142, 544974305445019651]
-    __version__ = "2.0.6"
+    __version__ = "2.0.7"
 
     def __init__(self, bot):
         self.bot = bot
@@ -103,7 +103,7 @@ class Termino(Utilities, commands.Cog, metaclass=CompositeMetaClass):
             conf = await self.confirmation(ctx, "restart")
         if not restart_conf or conf:
             await ctx.send(message)
-            log.info(f"{ctx.me.name} was restarted by {ctx.author} ({now})")
+            log.info(f"{ctx.me.name} was restarted by {ctx.author} ({nowstf()})")
             await self.config.restart_channel.set(ctx.channel.id)
             await self.config.restarted_author.set(ctx.author.name)
             try:
@@ -127,7 +127,7 @@ class Termino(Utilities, commands.Cog, metaclass=CompositeMetaClass):
             conf = await self.confirmation(ctx, "shutdown")
         if not shutdown_conf or conf:
             await ctx.send(message)
-            log.info(f"{ctx.me.name} was shutdown by {ctx.author} ({now})")
+            log.info(f"{ctx.me.name} was shutdown by {ctx.author} ({nowstf()})")
             try:
                 await asyncio.wait_for(self._send_announcement(), timeout=15.0)
             except asyncio.TimeoutError:

--- a/termino/utils.py
+++ b/termino/utils.py
@@ -11,6 +11,7 @@ from .mixins import MixinMeta
 
 RED_3_2_0 = version_info >= VersionInfo.from_str("3.2.0")
 default_wave = "\N{WAVING HAND SIGN}\N{EMOJI MODIFIER FITZPATRICK TYPE-3}"
+now = lambda: datetime.datetime.now()
 
 
 class Utilities(MixinMeta):
@@ -56,7 +57,7 @@ class Utilities(MixinMeta):
         kwargs = {
             "content": (
                 f"**{self.bot.user.name} {online[1]}**\n\n{online[0]}"
-                f"\n\n<t:{round(datetime.datetime.now().timestamp())}:R>"
+                f"\n\n<t:{round(now().timestamp())}:R>"
             )
         }
         if ch.permissions_for(ch.guild.me).embed_links:  # Wish I could use ctx.embed_requested


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes
Calls `now` every time it's supposed to be called and adds `now` as an alias for datetime.datetime.now for other cogs