### PR TITLE
Bump isort to 5.12.0

### DIFF
--- a/.github/workflows/run_precommit.yaml
+++ b/.github/workflows/run_precommit.yaml
@@ -14,7 +14,7 @@ jobs:
       # Setup Python and install pre-commit
       - uses: actions/setup-python@v2
         with:
-          python_version: "3.8"
+          python_version: "3.10"
       - name: Install pre-commit
         run: |
           pip install -U pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/isort
-    rev: '5.9.1'
+    rev: '5.12.0'
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Checks won't work until isort is at 5.12.0, which [does not support <3.10](https://github.com/home-assistant/core/issues/86892#issuecomment-1407763613).