### PR TITLE
FIXES: [EmbedCreator] "Author name" field is marked as required

### DIFF
--- a/embedcreator/embedcreator.py
+++ b/embedcreator/embedcreator.py
@@ -264,7 +264,7 @@ class EmbedAuthorBuilder(ModalBase):
             style=discord.TextStyle.short,
             max_length=256,
             default=self.view.embed.author.name,
-            required=True,
+            required=False,
         )
 
         self.embed_author_url = discord.ui.TextInput(


### PR DESCRIPTION
This pull request fixes #222

### Type

- [✔️] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes

Changed Author name to `required=False` in line `267` of `embedcreator.py`, and tested already locally.
