### PR TITLE
[Quotes] Fix use of the API (with an expired certificate).

### DIFF
--- a/quotes/quotes.py
+++ b/quotes/quotes.py
@@ -14,7 +14,7 @@ class Quotes(commands.Cog):
 
     def __init__(self, bot: Red):
         self.bot = bot
-        self.api = "https://api.quotable.io/random"
+        self.api = "http://api.quotable.io/random"
         self.session = aiohttp.ClientSession()
 
     async def cog_unload(self):


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Documentation

### Description of the changes

Good evening,

For the past 2 days, the web certificate for the API used in Quotes has expired, causing linked web requests to fail. This modification uses the `http` protocol instead of `https` to fix the problem temporarily while waiting for the problem to be fixed on the API side.

Thanks in advance,
Have a nice evening,
AAA3A